### PR TITLE
website: temporary hack to hide the logo from covering up the intro

### DIFF
--- a/website/source/index.html.erb
+++ b/website/source/index.html.erb
@@ -1,7 +1,7 @@
 <!-- Main jumbotron for a primary marketing message or call to action -->
 <div id="jumbotron">
 	<div class="container">
-		<div class="jumbo-logo"></div>
+		<div class="jumbo-logo hidden-xs hidden-sm hidden-md"></div>
 		<div class="col-lg-5">
 			<h2 class="rls-l">Serf is a decentralized solution for service discovery and orchestration that is lightweight, highly available, and fault tolerant.</h2>
 		</div>


### PR DESCRIPTION
The css is not super set-up to do responsive properly, but this makes it useable.
