### PR TITLE
Check that broadcast implements memberlist.Broadcast at compile time.

### DIFF
--- a/serf/broadcast.go
+++ b/serf/broadcast.go
@@ -4,6 +4,9 @@ import (
 	"github.com/hashicorp/memberlist"
 )
 
+// Check that broadcast implements the memberlist.Broadcast interface.
+var _ memberlist.Broadcast = &broadcast{}
+
 // broadcast is an implementation of memberlist.Broadcast and is used
 // to manage broadcasts across the memberlist channel that are related
 // only to Serf.

--- a/serf/broadcast_test.go
+++ b/serf/broadcast_test.go
@@ -1,20 +1,9 @@
 package serf
 
 import (
-	"github.com/hashicorp/memberlist"
 	"testing"
 	"time"
 )
-
-func TestBroadcast_impl(t *testing.T) {
-	t.Parallel()
-
-	var raw interface{}
-	raw = new(broadcast)
-	if _, ok := raw.(memberlist.Broadcast); !ok {
-		t.Fatalf("should be a Broadcast")
-	}
-}
 
 func TestBroadcastFinished(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
This is a cosmetic change which removes a unit test in favor of a compile time check.

We can assert the type of broadcast at compile time instead of using a unit test to do so.
