### PR TITLE
command/agent: unify configuration for bind address

### DIFF
--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -39,7 +39,7 @@ type Config struct {
 	// will bind to. Serf will use this address to bind to for both TCP
 	// and UDP connections. If no port is present in the address, the default
 	// port will be used.
-	BindAddr string `mapstructure:"bind_addr"`
+	BindAddr string `mapstructure:"bind"`
 
 	// EncryptKey is the secret key to use for encrypting communication
 	// traffic for Serf. The secret key must be exactly 16-bytes, base64

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -126,6 +126,17 @@ func TestDecodeConfig(t *testing.T) {
 	if config.Protocol != 7 {
 		t.Fatalf("bad: %#v", config)
 	}
+
+	// A bind addr
+	input = `{"bind": "127.0.0.2"}`
+	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if config.BindAddr != "127.0.0.2" {
+		t.Fatalf("bad: %#v", config)
+	}
 }
 
 func TestMergeConfig(t *testing.T) {

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -112,7 +112,7 @@ at a single JSON object with configuration within it.
 
 * `role` - Equivalent to the `-role` command-line flag.
 
-* `bind_addr` - Equivalent to the `-bind-addr` command-line flag.
+* `bind` - Equivalent to the `-bind` command-line flag.
 
 * `encrypt_key` - Equivalent to the `-encrypt` command-line flag.
 


### PR DESCRIPTION
Serf was using `bind` on the cli and `bind_addr` in the json configuration. This isn't very intuitive during configuration, as all other configurations map to the CLI equivalent.

However, this is an annoying change from a compatibility perspective, so makes sense if we want to omit it to avoid that headache.
