### PR TITLE
Expose Lamport time to user event script handlers.

### DIFF
--- a/command/agent/event_handler_test.go
+++ b/command/agent/event_handler_test.go
@@ -23,7 +23,7 @@ const userEventScript = `#!/bin/sh
 RESULT_FILE="%s"
 echo $SERF_SELF_NAME $SERF_SELF_ROLE >>${RESULT_FILE}
 echo $SERF_EVENT $SERF_USER_EVENT "$@" >>${RESULT_FILE}
-echo $SERF_EVENT $SERF_LAMPORT_TIME "$@" >>${RESULT_FILE}
+echo $SERF_EVENT $SERF_USER_LTIME "$@" >>${RESULT_FILE}
 while read line; do
 	printf "${line}\n" >>${RESULT_FILE}
 done

--- a/command/agent/invoke.go
+++ b/command/agent/invoke.go
@@ -57,7 +57,7 @@ func invokeEventScript(logger *log.Logger, script string, self serf.Member, even
 		go memberEventStdin(logger, stdin, &e)
 	case serf.UserEvent:
 		cmd.Env = append(cmd.Env, "SERF_USER_EVENT="+e.Name)
-		cmd.Env = append(cmd.Env, fmt.Sprintf("SERF_LAMPORT_TIME=%d", e.LTime))
+		cmd.Env = append(cmd.Env, fmt.Sprintf("SERF_USER_LTIME=%d", e.LTime))
 		go userEventStdin(logger, stdin, &e)
 	default:
 		return fmt.Errorf("Unknown event type: %s", event.EventType().String())

--- a/website/source/docs/agent/event-handlers.html.markdown
+++ b/website/source/docs/agent/event-handlers.html.markdown
@@ -32,7 +32,7 @@ variables:
 * `SERF_USER_EVENT` is the name of the user event type if `SERF_EVENT` is
   "user".
 
-* `SERF_LAMPORT_TIME` is the `LamportTime` of the user event if `SERF_EVENT`
+* `SERF_USER_LTIME` is the `LamportTime` of the user event if `SERF_EVENT`
   is "user".
 
 In addition to these environmental variables, the data for an event is passed


### PR DESCRIPTION
This adds a new environment variable, `SERF_LAMPORT_TIME` to user event handlers.  The relevant user event handler documentation has also been updated.  I also added a new test to cover user event handlers as well as confirming that SERF_LAMPORT_TIME is included in the environment.

This fixes #68.
