### PR TITLE
Ensure user-events have a newline

### DIFF
--- a/command/agent/invoke.go
+++ b/command/agent/invoke.go
@@ -108,10 +108,14 @@ func memberEventStdin(logger *log.Logger, stdin io.WriteCloser, e *serf.MemberEv
 
 // Sends data on stdin for a user event. The stdin simply contains the
 // payload (if any) of the event.
+// Most shells read implementations need a newline, force it to be there 
 func userEventStdin(logger *log.Logger, stdin io.WriteCloser, e *serf.UserEvent) {
-	defer stdin.Close()
-	if _, err := stdin.Write(e.Payload); err != nil {
-		logger.Printf("[ERR] Error writing user event payload: %s", err)
-		return
-	}
+    defer stdin.Close()
+    _, err := stdin.Write([]byte(fmt.Sprintf(
+        "%s\n",
+        bytes.TrimSuffix(e.Payload, []byte("\n")))))
+    if err != nil {
+        logger.Printf("[ERR] Error writing user event payload: %s", err)
+        return
+    }
 }


### PR DESCRIPTION
This is a fix for https://github.com/hashicorp/serf/issues/54
