### PR TITLE
Fix demo AMIs

### DIFF
--- a/demo/web-load-balancer/cloudformation.json
+++ b/demo/web-load-balancer/cloudformation.json
@@ -115,7 +115,7 @@
             "Properties" : {
                 "SubnetId" : { "Ref" : "PublicSubnet" },
                 "SourceDestCheck" : "false",
-                "ImageId" : "ami-c6699baf",
+                "ImageId" : "ami-3bcc9e7e",
                 "SecurityGroupIds" : [
                     { "Ref" : "InstanceSecurityGroup" }
                 ],
@@ -128,7 +128,7 @@
         "LoadBalancer": {
             "Type": "AWS::EC2::Instance",
             "Properties": {
-                "ImageId": "ami-ad3660c4",
+                "ImageId": "ami-acf9cde9",
                 "PrivateIpAddress": "10.0.0.5",
                 "SecurityGroupIds": [
                     {"Ref": "InstanceSecurityGroup"}
@@ -171,7 +171,7 @@
         "WebLaunchConfig": {
             "Type": "AWS::AutoScaling::LaunchConfiguration",
             "Properties": {
-                "ImageId": "ami-ad3660c4",
+                "ImageId": "ami-acf9cde9",
                 "InstanceType": "m1.small",
                 "SecurityGroups": [
                     {"Ref": "InstanceSecurityGroup"}


### PR DESCRIPTION
The AMI's in the demo do not work. This is not the most extensible fix, as it will only work in `us-west-1`, but it is certainly better than the demo not working at all. The best approach would be tracking down all the correct ami's and using maps so that the demo works regardless of the region it is launched in.

This is detailed further in https://github.com/hashicorp/serf/issues/108
