### PR TITLE
Humanize member list output

### DIFF
--- a/command/members.go
+++ b/command/members.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/hashicorp/serf/command/agent"
 	"github.com/mitchellh/cli"
+	"github.com/ryanuber/columnize"
 	"net"
 	"regexp"
 	"strings"
@@ -34,7 +35,7 @@ type MemberContainer struct {
 }
 
 func (c MemberContainer) String() string {
-	var result string
+	var result []string
 	for _, member := range c.Members {
 		// Format the tags as tag1=v1,tag2=v2,...
 		var tagPairs []string
@@ -43,16 +44,17 @@ func (c MemberContainer) String() string {
 		}
 		tags := strings.Join(tagPairs, ",")
 
-		result += fmt.Sprintf("%s     %s    %s    %s",
+		line := fmt.Sprintf("%s|%s|%s|%s",
 			member.Name, member.Addr, member.Status, tags)
 		if member.detail {
-			result += fmt.Sprintf(
-				"    Protocol Version: %d    Available Protocol Range: [%d, %d]",
+			line += fmt.Sprintf(
+				"|Protocol Version: %d|Available Protocol Range: [%d, %d]",
 				member.Proto["version"], member.Proto["min"], member.Proto["max"])
 		}
-		result += "\n"
+		result = append(result, line)
 	}
-	return result
+	output, _ := columnize.SimpleFormat(result)
+	return output
 }
 
 func (c *MembersCommand) Help() string {


### PR DESCRIPTION
Sometimes when looking at the `members` output when there are a number of nodes running, my OCD side wont quit telling me to fix the alignment. I started writing a patch for formatting output into more readable columns, which I later realized is likely a common want for CLI stuff.

I ended up writing a [little library](https://github.com/ryanuber/columnize) to do it, and this patch uses it for the `members` command. That said, I fully realize that there might be concern linking my library from a Hashicorp project, since you may not want to give some stranger the ability to break your builds, what with the lack of version control in `go get`, so by all means feel free to not merge this in.

I also considered sending this to [mitchellh/cli](https://github.com/mitchellh/cli) as a new output function, but didn't because I don't know that a CLI is the only case where someone might want to use this. I'm open to any suggestions on how to localize control of this.

Anyways, here is a quick example, before:

```
somenode001     10.77.5.101:7946    alive    role=web    Protocol Version: 3    Available Protocol Range: [1, 3]
someothernode023     127.0.0.1:7947    alive    role=db    Protocol Version: 3    Available Protocol Range: [1, 3]
short     127.0.0.1:7948    alive    role=db,datacenter=east    Protocol Version: 3    Available Protocol Range: [1, 3]
abcdef     127.0.0.1:7949    alive    role=queue,datacenter=west    Protocol Version: 3    Available Protocol Range: [1, 3]
xyz123     127.0.0.1:7950    alive    role=cache,version=1,release=123    Protocol Version: 3    Available Protocol Range: [1, 3]
node002     127.0.0.1:7951    alive    role=cache    Protocol Version: 3    Available Protocol Range: [1, 3]
udk-sked-991     127.0.0.1:7952    alive    role=web    Protocol Version: 3    Available Protocol Range: [1, 3]
yetanother00     127.0.0.1:7953    alive    role=lb    Protocol Version: 3    Available Protocol Range: [1, 3]
```

And after:

```
somenode001       10.77.5.101:7946  alive  role=web                          Protocol Version: 3  Available Protocol Range: [1, 3]
someothernode023  127.0.0.1:7947    alive  role=db                           Protocol Version: 3  Available Protocol Range: [1, 3]
short             127.0.0.1:7948    alive  role=db,datacenter=east           Protocol Version: 3  Available Protocol Range: [1, 3]
abcdef            127.0.0.1:7949    alive  role=queue,datacenter=west        Protocol Version: 3  Available Protocol Range: [1, 3]
xyz123            127.0.0.1:7950    alive  role=cache,version=1,release=123  Protocol Version: 3  Available Protocol Range: [1, 3]
node002           127.0.0.1:7951    alive  role=cache                        Protocol Version: 3  Available Protocol Range: [1, 3]
udk-sked-991      127.0.0.1:7952    alive  role=web                          Protocol Version: 3  Available Protocol Range: [1, 3]
yetanother00      127.0.0.1:7953    alive  role=lb                           Protocol Version: 3  Available Protocol Range: [1, 3]
```

There aren't tests because the current tests already do not mandate strict spacing rules for `members`, and that seems reasonable to me. Any `grep`, `awk`, etc commmands should still work as well, there is just added padding in the columns to make them more aligned.
