### PR TITLE
Copy cmd.Env fron os.Environ() to inherit from the OS environment. Fixes...

### DIFF
--- a/command/agent/invoke.go
+++ b/command/agent/invoke.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/serf/serf"
 	"io"
 	"log"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -42,7 +43,7 @@ func invokeEventScript(logger *log.Logger, script string, self serf.Member, even
 
 	cmd := exec.Command(shell, flag, script)
 	cmd.Args[0] = "serf-event"
-	cmd.Env = append(cmd.Env,
+	cmd.Env = append(os.Environ(),
 		"SERF_EVENT="+event.EventType().String(),
 		"SERF_SELF_NAME="+self.Name,
 		"SERF_SELF_ROLE="+self.Tags["role"],


### PR DESCRIPTION
Based on a quick test of echoing an exported environment variable, this approach works. If cmd.Env was never overwritten, the OS environment would have passed through. Still thinking about ways to properly test this change.
