### PR TITLE
agent: don't accept unknown configuration directives

### DIFF
--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -218,6 +218,7 @@ func DecodeConfig(r io.Reader) (*Config, error) {
 	msdec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		Metadata: &md,
 		Result:   &result,
+		ErrorUnused: true,
 	})
 	if err != nil {
 		return nil, err

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -272,6 +272,14 @@ func TestDecodeConfig(t *testing.T) {
 	}
 }
 
+func TestDecodeConfig_unknownDirective(t *testing.T) {
+	input := `{"unknown_directive": "titi"}`
+	_, err := DecodeConfig(bytes.NewReader([]byte(input)))
+	if err == nil {
+		t.Fatal("should have err")
+	}
+}
+
 func TestMergeConfig(t *testing.T) {
 	a := &Config{
 		NodeName:      "foo",


### PR DESCRIPTION
If an unknown configuration directive is present, it is better not to
ignore it as it can be a typo error.
