### PR TITLE
Fix incorrectly capitalized command in RPC docs

### DIFF
--- a/website/source/docs/agent/rpc.html.markdown
+++ b/website/source/docs/agent/rpc.html.markdown
@@ -28,7 +28,7 @@ All RPC requests have a request header, and some requests have
 a request body. The request header looks like:
 
 ```
-    {"Command": "Handshake", "Seq": 0}
+    {"Command": "handshake", "Seq": 0}
 ```
 
 All responses have a response header, and some may contain


### PR DESCRIPTION
Fixes an error in the RPC documentation where the `handshake` command is incorrectly capitalized. The agent refuses to acknowledge `Handshake` as a valid command.
