### PR TITLE
preventing panic in merge_delegate.go

### DIFF
--- a/serf/merge_delegate.go
+++ b/serf/merge_delegate.go
@@ -15,24 +15,24 @@ type mergeDelegate struct {
 }
 
 func (m *mergeDelegate) NotifyMerge(nodes []*memberlist.Node) (cancel bool) {
-	if m.serf.config.Merge != nil {
-		members := make([]*Member, len(nodes))
-		for idx, n := range nodes {
-			members[idx] = &Member{
-				Name:        n.Name,
-				Addr:        net.IP(n.Addr),
-				Port:        n.Port,
-				Tags:        m.serf.decodeTags(n.Meta),
-				Status:      StatusNone,
-				ProtocolMin: n.PMin,
-				ProtocolMax: n.PMax,
-				ProtocolCur: n.PCur,
-				DelegateMin: n.DMin,
-				DelegateMax: n.DMax,
-				DelegateCur: n.DCur,
-			}
-		}
-		return m.serf.config.Merge.NotifyMerge(members)
+	if m.serf.config.Merge == nil {
+		return false
 	}
-	return false
+	members := make([]*Member, len(nodes))
+	for idx, n := range nodes {
+		members[idx] = &Member{
+			Name:        n.Name,
+			Addr:        net.IP(n.Addr),
+			Port:        n.Port,
+			Tags:        m.serf.decodeTags(n.Meta),
+			Status:      StatusNone,
+			ProtocolMin: n.PMin,
+			ProtocolMax: n.PMax,
+			ProtocolCur: n.PCur,
+			DelegateMin: n.DMin,
+			DelegateMax: n.DMax,
+			DelegateCur: n.DCur,
+		}
+	}
+	return m.serf.config.Merge.NotifyMerge(members)
 }

--- a/serf/merge_delegate.go
+++ b/serf/merge_delegate.go
@@ -15,21 +15,24 @@ type mergeDelegate struct {
 }
 
 func (m *mergeDelegate) NotifyMerge(nodes []*memberlist.Node) (cancel bool) {
-	members := make([]*Member, len(nodes))
-	for idx, n := range nodes {
-		members[idx] = &Member{
-			Name:        n.Name,
-			Addr:        net.IP(n.Addr),
-			Port:        n.Port,
-			Tags:        m.serf.decodeTags(n.Meta),
-			Status:      StatusNone,
-			ProtocolMin: n.PMin,
-			ProtocolMax: n.PMax,
-			ProtocolCur: n.PCur,
-			DelegateMin: n.DMin,
-			DelegateMax: n.DMax,
-			DelegateCur: n.DCur,
+	if m.serf.config.Merge != nil {
+		members := make([]*Member, len(nodes))
+		for idx, n := range nodes {
+			members[idx] = &Member{
+				Name:        n.Name,
+				Addr:        net.IP(n.Addr),
+				Port:        n.Port,
+				Tags:        m.serf.decodeTags(n.Meta),
+				Status:      StatusNone,
+				ProtocolMin: n.PMin,
+				ProtocolMax: n.PMax,
+				ProtocolCur: n.PCur,
+				DelegateMin: n.DMin,
+				DelegateMax: n.DMax,
+				DelegateCur: n.DCur,
+			}
 		}
+		return m.serf.config.Merge.NotifyMerge(members)
 	}
-	return m.serf.config.Merge.NotifyMerge(members)
+	return false
 }


### PR DESCRIPTION
I was getting a panic in this code when not using any merge delegate. This fixes it, if this is a reasonable solution for your design.