### PR TITLE
bump to 0.6.4-2

### DIFF
--- a/serf/serf_test.go
+++ b/serf/serf_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1601,10 +1600,9 @@ type CancelMergeDelegate struct {
 	invoked bool
 }
 
-func (c *CancelMergeDelegate) NotifyMerge(members []*Member) (cancel bool) {
-	log.Printf("Merge canceled")
+func (c *CancelMergeDelegate) NotifyMerge(members []*Member) error {
 	c.invoked = true
-	return true
+	return fmt.Errorf("Merge canceled")
 }
 
 func TestSerf_Join_Cancel(t *testing.T) {

--- a/version.go
+++ b/version.go
@@ -4,7 +4,7 @@ package main
 var GitCommit string
 
 // The main version number that is being run at the moment.
-const Version = "0.6.4-1"
+const Version = "0.6.4-2"
 
 // A pre-release marker for the version. If this is "" (empty string)
 // then it means that it is a final release. Otherwise, this is a pre-release


### PR DESCRIPTION
This is required so that our new rpm build will replace old version during system update.