### PR TITLE
IPC: Tags - DeleteTags is not handled properly.

### DIFF
--- a/command/agent/ipc.go
+++ b/command/agent/ipc.go
@@ -941,6 +941,8 @@ func (i *AgentIPC) handleTags(client *IPCClient, seq uint64) error {
 		}
 		if !delTag {
 			tags[key] = val
+		} else {
+			delete(tags, key)
 		}
 	}
 


### PR DESCRIPTION
This fix actually deletes the key from the map if a key is specified in the DeleteTags list.