### PR TITLE
Bumps protocol version to 5 to get memberlist version 3.

### DIFF
--- a/serf/config.go
+++ b/serf/config.go
@@ -15,6 +15,7 @@ var ProtocolVersionMap map[uint8]uint8
 
 func init() {
 	ProtocolVersionMap = map[uint8]uint8{
+		5: 3,
 		4: 2,
 		3: 2,
 		2: 2,

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -24,7 +24,7 @@ import (
 // version to memberlist below.
 const (
 	ProtocolVersionMin uint8 = 2
-	ProtocolVersionMax       = 4
+	ProtocolVersionMax       = 5
 )
 
 const (


### PR DESCRIPTION
This can't be merged until hashicorp/memberlist#37 has been merged. It ups the corresponding serf version which maps to the new memberlist version.