### PR TITLE
Updates docs

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -682,7 +682,7 @@ Usage: serf agent [options]
 
 Options:
 
-  -bind=0.0.0.0            Address to bind network listeners to
+  -bind=0.0.0.0:7946       Address to bind network listeners to.
   -iface                   Network interface to bind to. Can be used instead of
                            -bind if the interface is known but not the address.
                            If both are provided, then Serf verifies that the
@@ -695,7 +695,7 @@ Options:
                            from. This will read every file ending in ".json"
                            as configuration in this directory in alphabetical
                            order.
-  -discover=cluster        Discover is set to enable mDNS discovery of peer. On
+  -discover=cluster        A cluster name used to discovery peers. On
                            networks that support multicast, this can be used to have
                            peers join each other without an explicit join.
   -encrypt=foo             Key for encrypting network traffic within Serf.

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -63,8 +63,8 @@ The options below are all specified on the command-line.
   in alphabetical order. For more information on the format of the configuration
   files, see the "Configuration Files" section below.
 
-* `-discover` - Discover provides a cluster name, which is used with mDNS to
-  automatically discover Serf peers. When provided, Serf will respond to mDNS
+* `-discover` - A cluster name, which is used with mDNS to
+  automatically discover peers. When provided, Serf will respond to mDNS
   queries and periodically poll for new peers. This feature requires a network
   environment that supports multicasting.
 


### PR DESCRIPTION
* Reword explanation for `-discover`
* Add default port to -bind (matches -rpc-addr)