### PR TITLE
Bumps protocol version back down as we've made memberlist smarter.

### DIFF
--- a/serf/config.go
+++ b/serf/config.go
@@ -15,7 +15,6 @@ var ProtocolVersionMap map[uint8]uint8
 
 func init() {
 	ProtocolVersionMap = map[uint8]uint8{
-		5: 3,
 		4: 2,
 		3: 2,
 		2: 2,

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -24,7 +24,7 @@ import (
 // version to memberlist below.
 const (
 	ProtocolVersionMin uint8 = 2
-	ProtocolVersionMax       = 5
+	ProtocolVersionMax       = 4
 )
 
 const (


### PR DESCRIPTION
Over on https://github.com/hashicorp/memberlist/pull/50 we made memberlist smarter about interoperating with v2/v3 so we don't need to bump the Serf protocol; this should ease rolling out newer versions of Serf and Consul.