### PR TITLE
Initial attempt at dumping running config with 'getconfig' RPC command

### DIFF
--- a/client/const.go
+++ b/client/const.go
@@ -13,6 +13,7 @@ const (
 const (
 	handshakeCommand       = "handshake"
 	eventCommand           = "event"
+	getConfigCommand       = "getconfig"
 	forceLeaveCommand      = "force-leave"
 	joinCommand            = "join"
 	membersCommand         = "members"

--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -365,6 +365,18 @@ func (c *RPCClient) Stats() (map[string]map[string]string, error) {
 	return resp, err
 }
 
+// Stats is used to get the running config data
+func (c *RPCClient) GetConfig() (string, error) {
+	header := requestHeader{
+		Command: getConfigCommand,
+		Seq:     c.getSeq(),
+	}
+	var resp string
+
+	err := c.genericRPC(&header, nil, &resp)
+	return resp, err
+}
+
 type monitorHandler struct {
 	client *RPCClient
 	closed bool

--- a/command/agent/ipc.go
+++ b/command/agent/ipc.go
@@ -47,6 +47,7 @@ const (
 const (
 	handshakeCommand       = "handshake"
 	eventCommand           = "event"
+	getConfigCommand       = "getconfig"
 	forceLeaveCommand      = "force-leave"
 	joinCommand            = "join"
 	membersCommand         = "members"
@@ -476,6 +477,9 @@ func (i *AgentIPC) handleRequest(client *IPCClient, reqHeader *requestHeader) er
 	case eventCommand:
 		return i.handleEvent(client, seq)
 
+	case getConfigCommand:
+		return i.handleGetConfig(client, seq)
+
 	case membersCommand, membersFilteredCommand:
 		return i.handleMembers(client, command, seq)
 
@@ -568,6 +572,19 @@ func (i *AgentIPC) handleAuth(client *IPCClient, seq uint64) error {
 		resp.Error = invalidAuthToken
 	}
 	return client.Send(&resp, nil)
+}
+
+func (i *AgentIPC) handleGetConfig(client *IPCClient, seq uint64) error {
+
+	// Attempt the send
+	resp := i.agent.GetConfig()
+
+	// Respond
+	header := responseHeader{
+		Seq:   seq,
+		Error: "",
+	}
+	return client.Send(&header, resp)
 }
 
 func (i *AgentIPC) handleEvent(client *IPCClient, seq uint64) error {

--- a/command/getconfig.go
+++ b/command/getconfig.go
@@ -1,0 +1,59 @@
+package command
+
+import (
+	"flag"
+	"fmt"
+	"github.com/mitchellh/cli"
+	"strings"
+)
+
+// GetConfigCommand is a Command implementation that queries a running
+// Serf agent for the current config
+type GetConfigCommand struct {
+	Ui cli.Ui
+}
+
+func (i *GetConfigCommand) Help() string {
+	helpText := `
+Usage: serf getconfig [options]
+
+	Dumps the active config data for the running serf agent
+
+Options:
+
+  -rpc-addr=127.0.0.1:7373 RPC address of the Serf agent.
+
+  -rpc-auth=""             RPC auth token of the Serf agent.
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (i *GetConfigCommand) Run(args []string) int {
+	cmdFlags := flag.NewFlagSet("config", flag.ContinueOnError)
+	cmdFlags.Usage = func() { i.Ui.Output(i.Help()) }
+	rpcAddr := RPCAddrFlag(cmdFlags)
+	rpcAuth := RPCAuthFlag(cmdFlags)
+	if err := cmdFlags.Parse(args); err != nil {
+		return 1
+	}
+
+	client, err := RPCClient(*rpcAddr, *rpcAuth)
+	if err != nil {
+		i.Ui.Error(fmt.Sprintf("Error connecting to Serf agent: %s", err))
+		return 1
+	}
+	defer client.Close()
+
+	config_data, err := client.GetConfig()
+	if err != nil {
+		i.Ui.Error(fmt.Sprintf("Error querying agent: %s", err))
+		return 1
+	}
+
+	i.Ui.Output(config_data)
+	return 0
+}
+
+func (i *GetConfigCommand) Synopsis() string {
+	return "Dumps the config for the running serf agent"
+}

--- a/commands.go
+++ b/commands.go
@@ -22,6 +22,12 @@ func init() {
 			}, nil
 		},
 
+		"getconfig": func() (cli.Command, error) {
+			return &command.GetConfigCommand{
+				Ui: ui,
+			}, nil
+		},
+
 		"event": func() (cli.Command, error) {
 			return &command.EventCommand{
 				Ui: ui,


### PR DESCRIPTION
@slackpad for review.

As discussed in https://github.com/hashicorp/serf/issues/306, this adds support for dumping the running serf config with a new RPC command 'getconfig'.

I've only added one import, with is 'crypto/sha256' so that I can redact sensitive fields (an alternative would be to just always print "REDACTED" instead, but I noticed that vault uses this pattern of sha256-summing sensitive data, so I figured it was a decent pattern to stick with).

This is a fairly naive attempt, and I don't really do much error handling (any), but I figure there isn't too much that can go wrong with just JSON marshalling the running config. I haven't added any tests yet either. I admittedly used a bit of a hack in order to support redacting data of marshalling then immediately unmarshalling the running config in order to obtain a copy. After redacting, I then pretty-print the JSON with indents.

Possibly enhancements:

* Tests
* Error handling
* Better way of knowing what data to redact
* Support for multiple output formats (though, I can't see anyone *not* wanting JSON here).

Sample output:

```
serf getconfig
{
    "NodeName": "localhost",
    "Role": "",
    "Tags": {},
    "TagsFile": "",
    "BindAddr": "0.0.0.0",
    "AdvertiseAddr": "",
    "EncryptKey": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
    "KeyringFile": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
    "LogLevel": "INFO",
    "RPCAddr": "127.0.0.1:7373",
    "RPCAuthKey": "",
    "Protocol": 5,
    "ReplayOnJoin": false,
    "StartJoin": [],
    "EventHandlers": [],
    "Profile": "lan",
    "SnapshotPath": "",
    "LeaveOnTerm": false,
    "SkipLeaveOnInt": false,
    "Discover": "",
    "Interface": "",
    "ReconnectIntervalRaw": "",
    "ReconnectInterval": 0,
    "ReconnectTimeoutRaw": "",
    "ReconnectTimeout": 0,
    "TombstoneTimeoutRaw": "",
    "TombstoneTimeout": 0,
    "DisableNameResolution": false,
    "EnableSyslog": false,
    "SyslogFacility": "LOCAL0",
    "RetryJoin": [],
    "RetryMaxAttempts": 0,
    "RetryIntervalRaw": "",
    "RetryInterval": 30000000000,
    "RejoinAfterLeave": false,
    "StatsiteAddr": "",
    "StatsdAddr": ""
}
```