### PR TITLE
Show event handlers in info output

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -419,12 +419,13 @@ func (a *Agent) loadKeyringFile(keyringFile string) error {
 // Stats is used to get various runtime information and stats
 func (a *Agent) Stats() map[string]map[string]string {
 	local := a.serf.LocalMember()
-	handlers := make(map[string]string)
+	event_handlers := make(map[string]string)
+	var script_filter string
 
 	// Convert event handlres from a string slice to a string map
-	for _, handler := range a.agentConf.EventHandlers {
-		tokens := strings.SplitN(handler, "=", 2)
-		handlers[tokens[0]] = tokens[1]
+	for _, script := range a.agentConf.EventScripts() {
+		script_filter = fmt.Sprintf("%s:%s", script.EventFilter.Event, script.EventFilter.Name)
+		event_handlers[script_filter] = script.Script
 	}
 
 	output := map[string]map[string]string{
@@ -434,7 +435,7 @@ func (a *Agent) Stats() map[string]map[string]string {
 		"runtime":        runtimeStats(),
 		"serf":           a.serf.Stats(),
 		"tags":           local.Tags,
-		"event_handlers": handlers,
+		"event_handlers": event_handlers,
 	}
 	return output
 }

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -420,11 +420,10 @@ func (a *Agent) loadKeyringFile(keyringFile string) error {
 func (a *Agent) Stats() map[string]map[string]string {
 	local := a.serf.LocalMember()
 	event_handlers := make(map[string]string)
-	var script_filter string
 
-	// Convert event handlres from a string slice to a string map
+	// Convert event handlers from a string slice to a string map
 	for _, script := range a.agentConf.EventScripts() {
-		script_filter = fmt.Sprintf("%s:%s", script.EventFilter.Event, script.EventFilter.Name)
+		script_filter := fmt.Sprintf("%s:%s", script.EventFilter.Event, script.EventFilter.Name)
 		event_handlers[script_filter] = script.Script
 	}
 

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -419,13 +419,22 @@ func (a *Agent) loadKeyringFile(keyringFile string) error {
 // Stats is used to get various runtime information and stats
 func (a *Agent) Stats() map[string]map[string]string {
 	local := a.serf.LocalMember()
+	handlers := make(map[string]string)
+
+	// Convert event handlres from a string slice to a string map
+	for _, handler := range a.agentConf.EventHandlers {
+		tokens := strings.SplitN(handler, "=", 2)
+		handlers[tokens[0]] = tokens[1]
+	}
+
 	output := map[string]map[string]string{
 		"agent": map[string]string{
 			"name": local.Name,
 		},
-		"runtime": runtimeStats(),
-		"serf":    a.serf.Stats(),
-		"tags":    local.Tags,
+		"runtime":        runtimeStats(),
+		"serf":           a.serf.Stats(),
+		"tags":           local.Tags,
+		"event_handlers": handlers,
 	}
 	return output
 }


### PR DESCRIPTION
This is a much smaller PR than https://github.com/hashicorp/serf/pull/311 that achieves what I wanted to get from https://github.com/hashicorp/serf/issues/306 but by adding event_handlers as a field to the output of info, as suggested by @ryanuber.

I actually like this solution a lot better, and probably would have done this to start with if I had realized that info already had a bunch similar data in it.

There may still be some merit to the getconfig command, but I think for the most part it's a better approach to just add additional fields to info. This was the only data I really wanted to pull, so it's all I'm adding for now.

The cod should be fairly self-explanatory, it just loops over the EventHandlers, and splits it into key/value pairs by cutting it at the first "=" sign. This is then used to build a map[string]string, which is what 'output' already wants

@ryanuber @slackpad for review