### PR TITLE
Add example for specifying an IPv6 address.

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -682,7 +682,8 @@ Usage: serf agent [options]
 
 Options:
 
-  -bind=0.0.0.0:7946       Address to bind network listeners to.
+  -bind=0.0.0.0:7946       Address to bind network listeners to. To use an IPv6
+                           address, specify [::1] or [::1]:7946.
   -iface                   Network interface to bind to. Can be used instead of
                            -bind if the interface is known but not the address.
                            If both are provided, then Serf verifies that the

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -37,7 +37,7 @@ The options below are all specified on the command-line.
   "7946" will be used. An important compatibility note, protocol version 2
   introduces support for non-consistent ports across the cluster. For more information,
   see the [compatibility page](/docs/compatibility.html).
-  Note: To use an IPv6 address, specify "[::1]" or "[::1]:7946.
+  Note: To use an IPv6 address, specify "[::1]" or "[::1]:7946".
 
 * `-iface` - This flag can be used to provide a binding interface. It can be
   used instead of `-bind` if the interface is known but not the address. If both


### PR DESCRIPTION
See: Issue #315, PR #316.