### PR TITLE
Add "Edit this page" link everywhere except /

### DIFF
--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: git://github.com/hashicorp/middleman-hashicorp.git
-  revision: 76f0f284ad44cea0457484ea83467192f02daf87
+  revision: b152b6436348e8e1f9990436228b25b4c5c6fcb8
   specs:
     middleman-hashicorp (0.1.0)
       bootstrap-sass (~> 3.3)
       builder (~> 3.2)
       less (~> 2.6)
-      middleman (~> 3.3)
+      middleman (~> 3.4)
       middleman-livereload (~> 3.4)
       middleman-minify-html (~> 3.4)
       middleman-syntax (~> 2.0)
@@ -27,7 +27,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    autoprefixer-rails (5.2.1.3)
+    autoprefixer-rails (6.0.3)
       execjs
       json
     bootstrap-sass (3.3.5.1)
@@ -76,7 +76,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.7.0)
     json (1.8.3)
-    kramdown (1.8.0)
+    kramdown (1.9.0)
     less (2.6.0)
       commonjs (~> 0.2.7)
     libv8 (3.16.14.11)
@@ -121,9 +121,9 @@ GEM
     middleman-syntax (2.0.0)
       middleman-core (~> 3.2)
       rouge (~> 1.0)
-    mime-types (2.6.1)
+    mime-types (2.6.2)
     mini_portile (0.6.2)
-    minitest (5.8.0)
+    minitest (5.8.1)
     multi_json (1.11.2)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
@@ -145,13 +145,13 @@ GEM
     rack-ssl-enforcer (0.2.9)
     rack-test (0.6.3)
       rack (>= 1.0)
-    rb-fsevent (0.9.5)
+    rb-fsevent (0.9.6)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
-    redcarpet (3.3.2)
+    redcarpet (3.3.3)
     ref (2.0.0)
-    rouge (1.9.1)
-    sass (3.4.18)
+    rouge (1.10.1)
+    sass (3.4.19)
     sprockets (2.12.4)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -165,16 +165,16 @@ GEM
     therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)
       ref
-    thin (1.6.3)
+    thin (1.6.4)
       daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0)
+      eventmachine (~> 1.0, >= 1.0.4)
       rack (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uber (0.0.14)
+    uber (0.0.15)
     uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
@@ -186,3 +186,6 @@ PLATFORMS
 
 DEPENDENCIES
   middleman-hashicorp!
+
+BUNDLED WITH
+   1.10.6

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,0 +1,10 @@
+all: build
+
+init:
+	bundle
+
+dev: init
+	bundle exec middleman server
+
+build: init
+	bundle exec middleman build

--- a/website/README.md
+++ b/website/README.md
@@ -12,13 +12,7 @@ requests like any normal GitHub project, and we'll merge it in.
 
 ## Running the Site Locally
 
-Running the site locally is simple. Clone this repo and run the following
-commands:
-
-```
-$ bundle
-$ bundle exec middleman server
-```
+Running the site locally is simple. Clone this repo and run `make dev`.
 
 Then open up `localhost:4567`. Note that some URLs you may need to append
 ".html" to make them work (in the navigation and such).

--- a/website/config.rb
+++ b/website/config.rb
@@ -10,6 +10,7 @@ activate :hashicorp do |h|
   h.bintray_repo    = "mitchellh/serf"
   h.bintray_user    = "mitchellh"
   h.bintray_key     = ENV["BINTRAY_API_KEY"]
+  h.github_slug     = "hashicorp/serf"
 
   # Currently, Serf builds are not prefixed with serf_*
   h.bintray_prefixed = false

--- a/website/source/layouts/layout.erb
+++ b/website/source/layouts/layout.erb
@@ -44,6 +44,9 @@
             <li><a href="/intro/index.html">Intro</a></li>
             <li class="active"><a href="/docs/index.html">Docs</a></li>
             <li><a href="/community.html">Community</a></li>
+            <% if current_page.url != '/' %>
+              <li class="li-under"><a href="<%= github_url :current_page %>">Edit this page</a></li>
+            <% end %>
           </ul>
 
           <ul class="buttons nav navbar-nav rls-sb">


### PR DESCRIPTION
This PR adds an 'Edit this page' link everywhere on the [Serf website](https://serfdom.io/) except the homepage. Note that — owing to some deployment issues on a different site — I closed my [last PR to this effect](https://github.com/hashicorp/serf/pull/320) and opened this one. 

As in the other PR, I have added a `Makefile` to the `website` directory and updated the README accordingly. I have also updated the `Gemfile.lock` file to point to the latest `middleman-hashicorp` gem.