### PR TITLE
Remove unreachable error check

### DIFF
--- a/command/agent/ipc.go
+++ b/command/agent/ipc.go
@@ -376,11 +376,6 @@ func (i *AgentIPC) listen() {
 			&codec.MsgpackHandle{RawToString: true, WriteExt: true})
 		client.enc = codec.NewEncoder(client.writer,
 			&codec.MsgpackHandle{RawToString: true, WriteExt: true})
-		if err != nil {
-			i.logger.Printf("[ERR] agent.ipc: Failed to create decoder: %v", err)
-			conn.Close()
-			continue
-		}
 
 		// Register the client
 		i.Lock()


### PR DESCRIPTION
I believe this is a relict of the past. Error variable doesn't mutate here since last `err != nil` check.