### PR TITLE
Support restarting serf from within event handler script

### DIFF
--- a/ops-misc/systemd.conf
+++ b/ops-misc/systemd.conf
@@ -11,6 +11,12 @@ ExecPreStart=/usr/bin/install -d -g root -o root /etc/serf/
 ExecStart=/usr/local/bin/serf agent -config-dir=/etc/serf/
 # Use SIGINT instead of SIGTERM so serf can depart the cluster.
 KillSignal=SIGINT
+# Kill only the serf process and leave spawned processes running.
+# Required to support restarting serf from within a script spwaned by an event handler
+KillMode=process
+# Give serf some time to leave the cluster before killing it off
+TimeoutStopSec=5
+
 # Restart on success, failure, and any emitted signals like HUP.
 Restart=always
 # Wait ten seconds before respawn attempts.


### PR DESCRIPTION
The KillMode default of control-group will actually kill all spawned processes together with serf when you do `servicectl restart serf`. In the case of dpkg this leads to a circular problem where dpkg is aborted before the deb postinst script can finish.

This change fixes the problem and also gives serf 5 seconds to exit the cluster before systemd will kill it off with a SIGKILL.