### PR TITLE
Memberlist config

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -278,6 +278,46 @@ func (c *Command) setupAgent(config *Config, logOutput io.Writer) *Agent {
 		return nil
 	}
 
+	if config.ProfilePath != "" {
+		path := config.ProfilePath
+		f, err := os.Open(path)
+		defer f.Close()
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Error reading '%s': %s", path, err))
+			return nil
+		}
+		profileconfig, err := DecodeProfile(f)
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("ProfilePath: %v", err))
+			return nil
+		}
+
+		if profileconfig.TCPTimeout != 0 {
+			serfConfig.MemberlistConfig.TCPTimeout = profileconfig.TCPTimeout
+		}
+		if profileconfig.IndirectChecks != 0 {
+			serfConfig.MemberlistConfig.IndirectChecks = profileconfig.IndirectChecks
+		}
+		if profileconfig.SuspicionMult != 0 {
+			serfConfig.MemberlistConfig.SuspicionMult = profileconfig.SuspicionMult
+		}
+		if profileconfig.PushPullInterval != 0 {
+			serfConfig.MemberlistConfig.PushPullInterval = profileconfig.PushPullInterval
+		}
+		if profileconfig.ProbeTimeout != 0 {
+			serfConfig.MemberlistConfig.ProbeTimeout = profileconfig.ProbeTimeout
+		}
+		if profileconfig.ProbeInterval != 0 {
+			serfConfig.MemberlistConfig.ProbeInterval = profileconfig.ProbeInterval
+		}
+		if profileconfig.GossipNodes != 0 {
+			serfConfig.MemberlistConfig.GossipNodes = profileconfig.GossipNodes
+		}
+		if profileconfig.GossipInterval != 0 {
+			serfConfig.MemberlistConfig.GossipInterval = profileconfig.GossipInterval
+		}
+	}
+
 	serfConfig.MemberlistConfig.BindAddr = bindIP
 	serfConfig.MemberlistConfig.BindPort = bindPort
 	serfConfig.MemberlistConfig.AdvertiseAddr = advertiseIP

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -354,6 +354,17 @@ func TestDecodeConfig_unknownDirective(t *testing.T) {
 	}
 }
 
+func TestDecodeProfile(t *testing.T) {
+	input := `{"tcp_timeout: 10s"}`
+	profile, err := DecodeProfile(bytes.NewReader([]byte(input)))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if profile.TCPTimeout != 10 * time.Second {
+		t.Fatalf("bad: %#v", profile)
+	}
+}
+
 func TestMergeConfig(t *testing.T) {
 	a := &Config{
 		NodeName:      "foo",


### PR DESCRIPTION
Inspiered by #252. Add additional option to config `profile_path` for path of .json file with memberlist configuration options. For example:

```
{
   "profile": "lan",
   "profile_path: "memberlist.json"
}
```

In this example, we load  `lan` profile, but with some changes in memberlist.json

memberlist.json:

```
{
    "gossip_nodes": 7,
    "tcp_timeout": "8s"
}
```
