### PR TITLE
make query and query reponse configurable

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -289,6 +289,8 @@ func (c *Command) setupAgent(config *Config, logOutput io.Writer) *Agent {
 	serfConfig.ProtocolVersion = uint8(config.Protocol)
 	serfConfig.CoalescePeriod = 3 * time.Second
 	serfConfig.QuiescentPeriod = time.Second
+	serfConfig.QueryResponseSizeLimit = config.QueryResponseSizeLimit
+	serfConfig.QuerySizeLimit = config.QuerySizeLimit
 	serfConfig.UserCoalescePeriod = 3 * time.Second
 	serfConfig.UserQuiescentPeriod = time.Second
 	if config.ReconnectInterval != 0 {

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -23,16 +23,18 @@ const DefaultBindPort int = 7946
 func DefaultConfig() *Config {
 	return &Config{
 		DisableCoordinates: false,
-		Tags:               make(map[string]string),
-		BindAddr:           "0.0.0.0",
-		AdvertiseAddr:      "",
-		LogLevel:           "INFO",
-		RPCAddr:            "127.0.0.1:7373",
-		Protocol:           serf.ProtocolVersionMax,
-		ReplayOnJoin:       false,
-		Profile:            "lan",
-		RetryInterval:      30 * time.Second,
-		SyslogFacility:     "LOCAL0",
+		Tags:                   make(map[string]string),
+		BindAddr:               "0.0.0.0",
+		AdvertiseAddr:          "",
+		LogLevel:               "INFO",
+		RPCAddr:                "127.0.0.1:7373",
+		Protocol:               serf.ProtocolVersionMax,
+		ReplayOnJoin:           false,
+		Profile:                "lan",
+		RetryInterval:          30 * time.Second,
+		SyslogFacility:         "LOCAL0",
+		QueryResponseSizeLimit: 1024,
+		QuerySizeLimit:         1024,
 	}
 }
 
@@ -101,6 +103,9 @@ type Config struct {
 	// ReplayOnJoin tells Serf to replay past user events
 	// when joining based on a `StartJoin`.
 	ReplayOnJoin bool `mapstructure:"replay_on_join"`
+
+	QueryResponseSizeLimit int `mapstructure:"query_response_size_limit"`
+	QuerySizeLimit int `mapstructure:"query_size_limit"`
 
 	// StartJoin is a list of addresses to attempt to join when the
 	// agent starts. If Serf is unable to communicate with any of these
@@ -426,6 +431,12 @@ func MergeConfig(a, b *Config) *Config {
 	}
 	if b.StatsdAddr != "" {
 		result.StatsdAddr = b.StatsdAddr
+	}
+	if b.QueryResponseSizeLimit != 0 {
+		result.QueryResponseSizeLimit = b.QueryResponseSizeLimit
+	}
+	if b.QuerySizeLimit != 0 {
+		result.QuerySizeLimit = b.QuerySizeLimit
 	}
 
 	// Copy the event handlers

--- a/serf/config.go
+++ b/serf/config.go
@@ -149,6 +149,9 @@ type Config struct {
 	//
 	QueryTimeoutMult int
 
+	QueryResponseSizeLimit int
+	QuerySizeLimit int
+
 	// MemberlistConfig is the memberlist configuration that Serf will
 	// use to do the underlying membership management and gossip. Some
 	// fields in the MemberlistConfig will be overwritten by Serf no
@@ -235,6 +238,8 @@ func DefaultConfig() *Config {
 		TombstoneTimeout:             24 * time.Hour,
 		MemberlistConfig:             memberlist.DefaultLANConfig(),
 		QueryTimeoutMult:             16,
+		QueryResponseSizeLimit:       1024,
+		QuerySizeLimit:               1024,
 		EnableNameConflictResolution: true,
 		DisableCoordinates:           false,
 	}

--- a/serf/event.go
+++ b/serf/event.go
@@ -152,8 +152,8 @@ func (q *Query) Respond(buf []byte) error {
 	}
 
 	// Check the size limit
-	if len(raw) > QueryResponseSizeLimit {
-		return fmt.Errorf("response exceeds limit of %d bytes", QueryResponseSizeLimit)
+	if len(raw) > q.serf.config.QueryResponseSizeLimit {
+		return fmt.Errorf("response exceeds limit of %d bytes", q.serf.config.QueryResponseSizeLimit)
 	}
 
 	// Send the response

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -215,8 +215,6 @@ type queries struct {
 
 const (
 	UserEventSizeLimit     = 512        // Maximum byte size for event name and payload
-	QuerySizeLimit         = 1024       // Maximum byte size for query
-	QueryResponseSizeLimit = 1024       // Maximum bytes size for response
 	snapshotSizeLimit      = 128 * 1024 // Maximum 128 KB snapshot
 )
 
@@ -513,8 +511,8 @@ func (s *Serf) Query(name string, payload []byte, params *QueryParam) (*QueryRes
 	}
 
 	// Check the size
-	if len(raw) > QuerySizeLimit {
-		return nil, fmt.Errorf("query exceeds limit of %d bytes", QuerySizeLimit)
+	if len(raw) > s.config.QuerySizeLimit {
+		return nil, fmt.Errorf("query exceeds limit of %d bytes", s.config.QuerySizeLimit)
 	}
 
 	// Register QueryResponse to track acks and responses

--- a/serf/serf_test.go
+++ b/serf/serf_test.go
@@ -1496,13 +1496,31 @@ func TestSerf_Query_sizeLimit(t *testing.T) {
 	defer s1.Shutdown()
 
 	name := "this is too large a query"
-	payload := make([]byte, QuerySizeLimit)
+	payload := make([]byte, s1.config.QuerySizeLimit)
 	_, err = s1.Query(name, payload, nil)
 	if err == nil {
 		t.Fatalf("should get error")
 	}
 	if !strings.HasPrefix(err.Error(), "query exceeds limit of ") {
 		t.Fatalf("should get size limit error: %v", err)
+	}
+}
+
+func TestSerf_Query_sizeLimitIncreased(t *testing.T) {
+	// Create the s1 config with an event channel so we can listen
+	s1Config := testConfig()
+	s1, err := Create(s1Config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer s1.Shutdown()
+
+	name := "this is too large a query"
+	payload := make([]byte, s1.config.QuerySizeLimit)
+	s1.config.QuerySizeLimit = 2048
+	_, err = s1.Query(name, payload, nil)
+	if err != nil {
+		t.Fatalf("should not get error: %v", err)
 	}
 }
 


### PR DESCRIPTION
Here's a test show it working:
```
martin$ bin/serf query foo
Query 'foo' dispatched
Ack from 'host.local'
Response from 'host.local': 0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
Total Acks: 1
Total Responses: 1
```