### PR TITLE
modify sudo and ordering, use set -e fail early

### DIFF
--- a/scripts/setup_test_subnet.sh
+++ b/scripts/setup_test_subnet.sh
@@ -4,12 +4,8 @@
 # is a bug that it isn't routable and this causes errors.
 #
 
-# Check if loopback is setup
-ping -c 1 -W 10 127.0.0.2 > /dev/null 2>&1
-if [ $? -eq 0 ]
-then
-    exit
-fi
+# Fail if any commands fail (unchecked), namely sudo and ifconfig.
+set -e
 
 # If we're not on OS X, then error
 case $OSTYPE in
@@ -21,8 +17,16 @@ case $OSTYPE in
         ;;
 esac
 
+# Check if loopback is setup
+if ping -c 1 -W 10 127.0.0.2 > /dev/null 2>&1
+then
+    exit
+fi
+
 # Setup loopback
+echo "Using sudo to setup lo0 interface aliases for testing."
+sudo -v
 for ((i=2;i<256;i++))
 do
-    sudo ifconfig lo0 alias 127.0.0.$i up
+    sudo -n ifconfig lo0 alias 127.0.0.$i up
 done


### PR DESCRIPTION
Avoid calling sudo 253 times if the first one gets Ctrl-C'd.
Tell the user that sudo is prompting, and why.
Move the OS sanity check to the front, pre ping.

https://github.com/hashicorp/serf/issues/343