### PR TITLE
Forces unit tests to bind to IPv4 address.

### DIFF
--- a/command/agent/util_test.go
+++ b/command/agent/util_test.go
@@ -28,7 +28,7 @@ func drainEventCh(ch <-chan string) {
 
 func getRPCAddr() string {
 	for i := 0; i < 500; i++ {
-		l, err := net.Listen("tcp", fmt.Sprintf(":%d", rand.Int31n(25000)+1024))
+		l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", rand.Int31n(25000)+1024))
 		if err == nil {
 			l.Close()
 			return l.Addr().String()


### PR DESCRIPTION
It looks like the new Travis platform doesn't support IPv6 (https://blog.travis-ci.com/2015-11-27-moving-to-a-more-elastic-future) so explicitly choosing an IPv4 address to fix build failures. Here's an example build failure that looks IPv6-related - https://travis-ci.org/hashicorp/serf/builds/97754919.