### PR TITLE
Fixes intent queue overflow by storing intents per-node.

### DIFF
--- a/serf/config.go
+++ b/serf/config.go
@@ -121,12 +121,12 @@ type Config struct {
 	// prevent an unbounded growth of memory utilization
 	MaxQueueDepth int
 
-	// RecentIntentBuffer is used to set the size of recent join and leave intent
-	// messages that will be buffered. This is used to guard against
-	// the case where Serf broadcasts an intent that arrives before the
-	// Memberlist event. It is important that this not be too small to avoid
-	// continuous rebroadcasting of dead events.
-	RecentIntentBuffer int
+	// RecentIntentTimeout is used to determine how long we store recent
+	// join and leave intents. This is used to guard against the case where
+	// Serf broadcasts an intent that arrives before the Memberlist event.
+	// It is important that this not be too short to avoid continuous
+	// rebroadcasting of dead events.
+	RecentIntentTimeout time.Duration
 
 	// EventBuffer is used to control how many events are buffered.
 	// This is used to prevent re-delivery of events to a client. The buffer
@@ -242,7 +242,7 @@ func DefaultConfig() *Config {
 		LogOutput:                    os.Stderr,
 		ProtocolVersion:              ProtocolVersionMax,
 		ReapInterval:                 15 * time.Second,
-		RecentIntentBuffer:           128,
+		RecentIntentTimeout:          5 * time.Minute,
 		ReconnectInterval:            30 * time.Second,
 		ReconnectTimeout:             24 * time.Hour,
 		QueueDepthWarning:            128,

--- a/serf/delegate_test.go
+++ b/serf/delegate_test.go
@@ -186,12 +186,12 @@ func TestDelegate_MergeRemoteState(t *testing.T) {
 	}
 
 	// Verify pending join for test
-	if join, ok := recentIntent(s1.recentJoin, "test"); !ok || join != 20 {
+	if join, ok := recentIntent(s1.recentIntents, "test", messageJoinType); !ok || join != 20 {
 		t.Fatalf("bad recent join")
 	}
 
 	// Verify pending leave for foo
-	if leave, ok := recentIntent(s1.recentLeave, "foo"); !ok || leave != 15 {
+	if leave, ok := recentIntent(s1.recentIntents, "foo", messageLeaveType); !ok || leave != 15 {
 		t.Fatalf("bad recent leave")
 	}
 

--- a/serf/delegate_test.go
+++ b/serf/delegate_test.go
@@ -186,12 +186,12 @@ func TestDelegate_MergeRemoteState(t *testing.T) {
 	}
 
 	// Verify pending join for test
-	if s1.recentJoin[0].Node != "test" || s1.recentJoin[0].LTime != 20 {
+	if join, ok := recentIntent(s1.recentJoin, "test"); !ok || join != 20 {
 		t.Fatalf("bad recent join")
 	}
 
 	// Verify pending leave for foo
-	if s1.recentLeave[0].Node != "foo" || s1.recentLeave[0].LTime != 15 {
+	if leave, ok := recentIntent(s1.recentLeave, "foo"); !ok || leave != 15 {
 		t.Fatalf("bad recent leave")
 	}
 

--- a/serf/serf_internals_test.go
+++ b/serf/serf_internals_test.go
@@ -64,7 +64,7 @@ func TestSerf_join_pendingIntent(t *testing.T) {
 	}
 	defer s.Shutdown()
 
-	upsertIntent(s.recentJoin, "test", 5, time.Now)
+	upsertIntent(s.recentIntents, "test", messageJoinType, 5, time.Now)
 	n := memberlist.Node{Name: "test",
 		Addr: nil,
 		Meta: []byte("test"),
@@ -89,8 +89,8 @@ func TestSerf_join_pendingIntents(t *testing.T) {
 	}
 	defer s.Shutdown()
 
-	upsertIntent(s.recentJoin, "test", 5, time.Now)
-	upsertIntent(s.recentLeave, "test", 6, time.Now)
+	upsertIntent(s.recentIntents, "test", messageJoinType, 5, time.Now)
+	upsertIntent(s.recentIntents, "test", messageLeaveType, 6, time.Now)
 	n := memberlist.Node{Name: "test",
 		Addr: nil,
 		Meta: []byte("test"),
@@ -125,7 +125,7 @@ func TestSerf_leaveIntent_bufferEarly(t *testing.T) {
 	}
 
 	// Check that we buffered
-	if leave, ok := recentIntent(s.recentLeave, "test"); !ok || leave != 10 {
+	if leave, ok := recentIntent(s.recentIntents, "test", messageLeaveType); !ok || leave != 10 {
 		t.Fatalf("bad buffer")
 	}
 }
@@ -150,7 +150,7 @@ func TestSerf_leaveIntent_oldMessage(t *testing.T) {
 		t.Fatalf("should not rebroadcast")
 	}
 
-	if _, ok := recentIntent(s.recentLeave, "test"); ok {
+	if _, ok := recentIntent(s.recentIntents, "test", messageLeaveType); ok {
 		t.Fatalf("should not have buffered intent")
 	}
 }
@@ -175,7 +175,7 @@ func TestSerf_leaveIntent_newer(t *testing.T) {
 		t.Fatalf("should rebroadcast")
 	}
 
-	if _, ok := recentIntent(s.recentLeave, "test"); ok {
+	if _, ok := recentIntent(s.recentIntents, "test", messageLeaveType); ok {
 		t.Fatalf("should not have buffered intent")
 	}
 
@@ -206,7 +206,7 @@ func TestSerf_joinIntent_bufferEarly(t *testing.T) {
 	}
 
 	// Check that we buffered
-	if join, ok := recentIntent(s.recentJoin, "test"); !ok || join != 10 {
+	if join, ok := recentIntent(s.recentIntents, "test", messageJoinType); !ok || join != 10 {
 		t.Fatalf("bad buffer")
 	}
 }
@@ -229,7 +229,7 @@ func TestSerf_joinIntent_oldMessage(t *testing.T) {
 	}
 
 	// Check that we didn't buffer anything
-	if _, ok := recentIntent(s.recentJoin, "test"); ok {
+	if _, ok := recentIntent(s.recentIntents, "test", messageJoinType); ok {
 		t.Fatalf("should not have buffered intent")
 	}
 }
@@ -252,7 +252,7 @@ func TestSerf_joinIntent_newer(t *testing.T) {
 		t.Fatalf("should rebroadcast")
 	}
 
-	if _, ok := recentIntent(s.recentJoin, "test"); ok {
+	if _, ok := recentIntent(s.recentIntents, "test", messageJoinType); ok {
 		t.Fatalf("should not have buffered intent")
 	}
 
@@ -285,7 +285,7 @@ func TestSerf_joinIntent_resetLeaving(t *testing.T) {
 		t.Fatalf("should rebroadcast")
 	}
 
-	if _, ok := recentIntent(s.recentJoin, "test"); ok {
+	if _, ok := recentIntent(s.recentIntents, "test", messageJoinType); ok {
 		t.Fatalf("should not have buffered intent")
 	}
 

--- a/serf/serf_internals_test.go
+++ b/serf/serf_internals_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hashicorp/memberlist"
 	"github.com/hashicorp/serf/testutil"
 	"testing"
+	"time"
 )
 
 func TestSerf_joinLeave_ltime(t *testing.T) {
@@ -63,8 +64,7 @@ func TestSerf_join_pendingIntent(t *testing.T) {
 	}
 	defer s.Shutdown()
 
-	s.recentJoin[0] = nodeIntent{5, "test"}
-
+	upsertIntent(s.recentJoin, "test", 5, time.Now)
 	n := memberlist.Node{Name: "test",
 		Addr: nil,
 		Meta: []byte("test"),
@@ -89,9 +89,8 @@ func TestSerf_join_pendingIntents(t *testing.T) {
 	}
 	defer s.Shutdown()
 
-	s.recentJoin[0] = nodeIntent{5, "test"}
-	s.recentLeave[0] = nodeIntent{6, "test"}
-
+	upsertIntent(s.recentJoin, "test", 5, time.Now)
+	upsertIntent(s.recentLeave, "test", 6, time.Now)
 	n := memberlist.Node{Name: "test",
 		Addr: nil,
 		Meta: []byte("test"),
@@ -126,10 +125,7 @@ func TestSerf_leaveIntent_bufferEarly(t *testing.T) {
 	}
 
 	// Check that we buffered
-	if s.recentLeaveIndex != 1 {
-		t.Fatalf("bad index")
-	}
-	if s.recentLeave[0].Node != "test" || s.recentLeave[0].LTime != 10 {
+	if leave, ok := recentIntent(s.recentLeave, "test"); !ok || leave != 10 {
 		t.Fatalf("bad buffer")
 	}
 }
@@ -154,8 +150,8 @@ func TestSerf_leaveIntent_oldMessage(t *testing.T) {
 		t.Fatalf("should not rebroadcast")
 	}
 
-	if s.recentLeaveIndex != 0 {
-		t.Fatalf("bad index")
+	if _, ok := recentIntent(s.recentLeave, "test"); ok {
+		t.Fatalf("should not have buffered intent")
 	}
 }
 
@@ -179,8 +175,8 @@ func TestSerf_leaveIntent_newer(t *testing.T) {
 		t.Fatalf("should rebroadcast")
 	}
 
-	if s.recentLeaveIndex != 0 {
-		t.Fatalf("bad index")
+	if _, ok := recentIntent(s.recentLeave, "test"); ok {
+		t.Fatalf("should not have buffered intent")
 	}
 
 	if s.members["test"].Status != StatusLeaving {
@@ -210,10 +206,7 @@ func TestSerf_joinIntent_bufferEarly(t *testing.T) {
 	}
 
 	// Check that we buffered
-	if s.recentJoinIndex != 1 {
-		t.Fatalf("bad index")
-	}
-	if s.recentJoin[0].Node != "test" || s.recentJoin[0].LTime != 10 {
+	if join, ok := recentIntent(s.recentJoin, "test"); !ok || join != 10 {
 		t.Fatalf("bad buffer")
 	}
 }
@@ -235,8 +228,9 @@ func TestSerf_joinIntent_oldMessage(t *testing.T) {
 		t.Fatalf("should not rebroadcast")
 	}
 
-	if s.recentJoinIndex != 0 {
-		t.Fatalf("bad index")
+	// Check that we didn't buffer anything
+	if _, ok := recentIntent(s.recentJoin, "test"); ok {
+		t.Fatalf("should not have buffered intent")
 	}
 }
 
@@ -258,8 +252,8 @@ func TestSerf_joinIntent_newer(t *testing.T) {
 		t.Fatalf("should rebroadcast")
 	}
 
-	if s.recentJoinIndex != 0 {
-		t.Fatalf("bad index")
+	if _, ok := recentIntent(s.recentJoin, "test"); ok {
+		t.Fatalf("should not have buffered intent")
 	}
 
 	if s.members["test"].statusLTime != 14 {
@@ -291,8 +285,8 @@ func TestSerf_joinIntent_resetLeaving(t *testing.T) {
 		t.Fatalf("should rebroadcast")
 	}
 
-	if s.recentJoinIndex != 0 {
-		t.Fatalf("bad index")
+	if _, ok := recentIntent(s.recentJoin, "test"); ok {
+		t.Fatalf("should not have buffered intent")
 	}
 
 	if s.members["test"].statusLTime != 14 {

--- a/serf/serf_test.go
+++ b/serf/serf_test.go
@@ -847,6 +847,7 @@ func TestSerf_ReapHandler(t *testing.T) {
 	c := testConfig()
 	c.ReapInterval = time.Nanosecond
 	c.TombstoneTimeout = time.Second * 6
+	c.RecentIntentTimeout = time.Second * 7
 	s, err := Create(c)
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -860,6 +861,15 @@ func TestSerf_ReapHandler(t *testing.T) {
 		&memberState{m, 0, time.Now().Add(-10 * time.Second)},
 	}
 
+	upsertIntent(s.recentJoin, "foo", 1, time.Now)
+	upsertIntent(s.recentJoin, "bar", 2, func() time.Time {
+		return time.Now().Add(-10 * time.Second)
+	})
+	upsertIntent(s.recentLeave, "foo", 1, time.Now)
+	upsertIntent(s.recentLeave, "bar", 2, func() time.Time {
+		return time.Now().Add(-10 * time.Second)
+	})
+
 	go func() {
 		time.Sleep(time.Millisecond)
 		s.Shutdown()
@@ -869,6 +879,18 @@ func TestSerf_ReapHandler(t *testing.T) {
 
 	if len(s.leftMembers) != 2 {
 		t.Fatalf("should be shorter")
+	}
+	if _, ok := recentIntent(s.recentJoin, "foo"); !ok {
+		t.Fatalf("should be buffered")
+	}
+	if _, ok := recentIntent(s.recentJoin, "bar"); ok {
+		t.Fatalf("should be reaped")
+	}
+	if _, ok := recentIntent(s.recentLeave, "foo"); !ok {
+		t.Fatalf("should be buffered")
+	}
+	if _, ok := recentIntent(s.recentLeave, "bar"); ok {
+		t.Fatalf("should be reaped")
 	}
 }
 
@@ -886,7 +908,7 @@ func TestSerf_Reap(t *testing.T) {
 		&memberState{m, 0, time.Now().Add(-10 * time.Second)},
 	}
 
-	old = s.reap(old, time.Second*6)
+	old = s.reap(old, time.Now(), time.Second*6)
 	if len(old) != 2 {
 		t.Fatalf("should be shorter")
 	}
@@ -909,28 +931,71 @@ func TestRemoveOldMember(t *testing.T) {
 }
 
 func TestRecentIntent(t *testing.T) {
-	if recentIntent(nil, "foo") != nil {
-		t.Fatalf("should get nil on empty recent")
-	}
-	if recentIntent([]nodeIntent{}, "foo") != nil {
-		t.Fatalf("should get nil on empty recent")
+	if _, ok := recentIntent(nil, "foo"); ok {
+		t.Fatalf("should get nothing on empty recent")
 	}
 
-	recent := []nodeIntent{
-		nodeIntent{1, "foo"},
-		nodeIntent{2, "bar"},
-		nodeIntent{3, "baz"},
-		nodeIntent{4, "bar"},
-		nodeIntent{0, "bar"},
-		nodeIntent{5, "bar"},
+	now := time.Now()
+	expire := func() time.Time {
+		return now.Add(-2 * time.Second)
+	}
+	save := func() time.Time {
+		return now
 	}
 
-	if r := recentIntent(recent, "bar"); r.LTime != 4 {
-		t.Fatalf("bad time for bar")
+	intents := make(map[string]nodeIntent)
+	if _, ok := recentIntent(intents, "foo"); ok {
+		t.Fatalf("should get nothing on empty recent")
+	}
+	if added := upsertIntent(intents, "foo", 1, expire); !added {
+		t.Fatalf("should have added")
+	}
+	if added := upsertIntent(intents, "bar", 2, expire); !added {
+		t.Fatalf("should have added")
+	}
+	if added := upsertIntent(intents, "baz", 3, save); !added {
+		t.Fatalf("should have added")
+	}
+	if added := upsertIntent(intents, "bar", 4, expire); !added {
+		t.Fatalf("should have added")
+	}
+	if added := upsertIntent(intents, "bar", 0, expire); added {
+		t.Fatalf("should not have added")
+	}
+	if added := upsertIntent(intents, "bar", 5, expire); !added {
+		t.Fatalf("should have added")
 	}
 
-	if r := recentIntent(recent, "tubez"); r != nil {
-		t.Fatalf("got result for tubez")
+	if ltime, ok := recentIntent(intents, "foo"); !ok || ltime != 1 {
+		t.Fatalf("bad: %v %v", ok, ltime)
+	}
+	if ltime, ok := recentIntent(intents, "bar"); !ok || ltime != 5 {
+		t.Fatalf("bad: %v %v", ok, ltime)
+	}
+	if ltime, ok := recentIntent(intents, "baz"); !ok || ltime != 3 {
+		t.Fatalf("bad: %v %v", ok, ltime)
+	}
+	if _, ok := recentIntent(intents, "tubez"); ok {
+		t.Fatalf("should get nothing")
+	}
+
+	reapIntents(intents, now, time.Second)
+	if _, ok := recentIntent(intents, "foo"); ok {
+		t.Fatalf("should get nothing")
+	}
+	if _, ok := recentIntent(intents, "bar"); ok {
+		t.Fatalf("should get nothing")
+	}
+	if ltime, ok := recentIntent(intents, "baz"); !ok || ltime != 3 {
+		t.Fatalf("bad: %v %v", ok, ltime)
+	}
+	if _, ok := recentIntent(intents, "tubez"); ok {
+		t.Fatalf("should get nothing")
+	}
+
+	reapIntents(intents, now.Add(2*time.Second), time.Second)
+	if _, ok := recentIntent(intents, "baz"); ok {
+		t.Fatalf("should get nothing")
 	}
 }
 


### PR DESCRIPTION
This fixes https://github.com/hashicorp/consul/issues/1062 by storing the intents per-node. This will buffer all intents for a 5 minute period and intents are now stored in a map indexed per-node (later intents of each type by Lamport time will overwrite old ones). This should provide a reasonable footprint of memory usage without throwing out recent intents, which is what leads to the infinite rebroadcasts.