### PR TITLE
Use `make bin` instead of `make` for the travis install command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ branches:
     - master
 
 install:
-  - make
+  - make bin
   - make get-tools
 
 script:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -40,7 +40,7 @@ testrace:: subnet
 	go test -race `govendor list -no-status +local` $(TESTARGS)
 
 tools::
-	@go tool vet 2>/dev/null ; if [ $$? -eq 3 ]; then \
+	@which gox 2>/dev/null ; if [ $$? -eq 1 ]; then \
 		$(MAKE) get-tools; \
 	fi
 


### PR DESCRIPTION
This prevents travis from testing Serf twice, once during `make` and a second time during `make test`.  Found while looking at:

https://travis-ci.org/hashicorp/serf/builds/150837335