### PR TITLE
build: Add target for Illumos

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -17,7 +17,7 @@ GIT_DIRTY="$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)"
 
 # Determine the arch/os combos we're building for
 XC_ARCH=${XC_ARCH:-"386 amd64 arm"}
-XC_OS=${XC_OS:-"linux darwin windows freebsd openbsd"}
+XC_OS=${XC_OS:-"linux darwin windows freebsd openbsd solaris"}
 
 # Install dependencies
 echo "==> Getting dependencies..."


### PR DESCRIPTION
This commit adds `solaris` to the list of cross-compiled operating systems such that binaries capable of running on Illumos will be produced by `make bin`.

No other changes are necessary to allow building.