### PR TITLE
Expose BroadcastTimeout configuration parameter

### DIFF
--- a/cmd/serf/command/agent/config.go
+++ b/cmd/serf/command/agent/config.go
@@ -35,6 +35,7 @@ func DefaultConfig() *Config {
 		SyslogFacility:         "LOCAL0",
 		QueryResponseSizeLimit: 1024,
 		QuerySizeLimit:         1024,
+		BroadcastTimeout:       5 * time.Second,
 	}
 }
 
@@ -210,6 +211,12 @@ type Config struct {
 	// StatsdAddr is the address of a statsd instance. If provided,
 	// metrics will be sent to that instance.
 	StatsdAddr string `mapstructure:"statsd_addr"`
+
+	// BroadcastTimeoutRaw is the string retry interval. This interval
+	// controls the timeout for broadcast events. This defaults to
+	// 5 seconds.
+	BroadcastTimeoutRaw string        `mapstructure:"broadcast_timeout"`
+	BroadcastTimeout    time.Duration `mapstructure:"-"`
 }
 
 // BindAddrParts returns the parts of the BindAddr that should be
@@ -317,6 +324,14 @@ func DecodeConfig(r io.Reader) (*Config, error) {
 			return nil, err
 		}
 		result.RetryInterval = dur
+	}
+
+	if result.BroadcastTimeoutRaw != "" {
+		dur, err := time.ParseDuration(result.BroadcastTimeoutRaw)
+		if err != nil {
+			return nil, err
+		}
+		result.BroadcastTimeout = dur
 	}
 
 	return &result, nil
@@ -442,6 +457,9 @@ func MergeConfig(a, b *Config) *Config {
 	}
 	if b.QuerySizeLimit != 0 {
 		result.QuerySizeLimit = b.QuerySizeLimit
+	}
+	if b.BroadcastTimeout != 0 {
+		result.BroadcastTimeout = b.BroadcastTimeout
 	}
 
 	// Copy the event handlers

--- a/cmd/serf/command/agent/config_test.go
+++ b/cmd/serf/command/agent/config_test.go
@@ -300,6 +300,17 @@ func TestDecodeConfig(t *testing.T) {
 		t.Fatalf("bad: %#v", config)
 	}
 
+	// Broadcast timeout
+	input = `{"broadcast_timeout": "10s"}`
+	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if config.BroadcastTimeout != 10*time.Second {
+		t.Fatalf("bad: %#v", config)
+	}
+
 	// Retry configs
 	input = `{"retry_join": ["127.0.0.1", "127.0.0.2"]}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
@@ -400,6 +411,7 @@ func TestMergeConfig(t *testing.T) {
 		StatsiteAddr:           "127.0.0.1:8125",
 		QueryResponseSizeLimit: 123,
 		QuerySizeLimit:         456,
+		BroadcastTimeout:       20 * time.Second,
 	}
 
 	c := MergeConfig(a, b)
@@ -499,6 +511,10 @@ func TestMergeConfig(t *testing.T) {
 	}
 
 	if c.QueryResponseSizeLimit != 123 || c.QuerySizeLimit != 456 {
+		t.Fatalf("bad: %#v", c)
+	}
+
+	if c.BroadcastTimeout != 20*time.Second {
 		t.Fatalf("bad: %#v", c)
 	}
 }

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -184,6 +184,10 @@ The options below are all specified on the command-line.
   This flag can only be enabled on Linux or OSX systems, as Windows and Plan 9 do
   not provide the syslog facility.
 
+* `-broadcast-timeout` - Sets the broadcast timeout, which is the max time allowed for
+  responses to events including leave and force remove messages. Defaults to 5s. This
+  should use the "s" suffix for second, "m" for minute, or "h" for hour.
+
 ## Configuration Files
 
 In addition to the command-line options, configuration can be put into
@@ -311,6 +315,8 @@ at a single JSON object with configuration within it.
   payload sizes for queries, respectively. These must fit in a UDP packet with some
   additional overhead, so tuning these past the default values of 1024 will depend
   on your network configuration.
+
+* `broadcast_timeout` - Equivalent to the `-broadcast-timeout` command-line flag.
 
 #### Example Keyring File
 


### PR DESCRIPTION
(Per discussion in https://groups.google.com/forum/#!topic/serfdom/SgKQQ9LkDw0)

Exposes the broadcast timeout config param, which needs to be tuned for cases when tons of nodes join at the same time and the default 5 seconds is insufficient.

Tested by scaling from 0 to ~500 nodes as fast as possible (~90 seconds) a few times with a 30s broadcast timeout. Seems to resolve issue discussed in thread.