### PR TITLE
Added: Trying to recover from error state like disk-full.

### DIFF
--- a/serf/snapshot.go
+++ b/serf/snapshot.go
@@ -320,7 +320,14 @@ func (s *Snapshotter) appendLine(l string) error {
 
 	n, err := s.buffered.WriteString(l)
 	if err != nil {
-		return err
+		// Try to recover from error state like disk-full.
+		s.buffered.Reset(s.fh)
+
+		if err := s.buffered.Flush(); err != nil {
+			return err
+		} else {
+			s.lastFlush = time.Now()
+		}
 	}
 
 	// Check if we should flush


### PR DESCRIPTION
This is same following issue.

- [Snapshot open file descriptor permanently unusable after "filesystem full" condition #1744](https://github.com/hashicorp/consul/issues/1744)
- [Added: Trying to recover from error state like disk-full. #2236](https://github.com/hashicorp/consul/pull/2236)

serf uses bufio library to write the snapshot file.
bufio library can not recover from error state like disk-full unless calling Reset() even if the amount of disk free space is increased.

https://golang.org/pkg/bufio/#Reader.Reset

But Reset() discards any buffered data, resets all state.  
If the snapshot file is permissible to lose the old buffer data , this patch to fix this problem .

Best regards,
