### PR TITLE
Fix possible IP comparison error

### DIFF
--- a/serf/serf.go
+++ b/serf/serf.go
@@ -1353,7 +1353,7 @@ func (s *Serf) resolveNodeConflict() {
 
 		// Update the counters
 		responses++
-		if bytes.Equal(member.Addr, local.Addr) && member.Port == local.Port {
+		if member.Addr.Equal(local.Addr) && member.Port == local.Port {
 			matching++
 		}
 	}


### PR DESCRIPTION
A net.IP may be represented by both by a 4 as well as a 16 byte long byte slice. Because of this, it is not safe to compare IP addresses using bytes.Equal as the same IP address using a different internal representation will produce mismatches.

*Note, this PR was not initiated by my use of this package and noticing a bug, rather by creating an extension proposal for `go vet` and that signalling the possible misuse in this library.*

Cheers :)