### PR TITLE
Relay query responses through a few randomly chosen nodes

### DIFF
--- a/client/const.go
+++ b/client/const.go
@@ -144,6 +144,7 @@ type queryRequest struct {
 	FilterNodes []string
 	FilterTags  map[string]string
 	RequestAck  bool
+	RelayFactor uint8
 	Timeout     time.Duration
 	Name        string
 	Payload     []byte

--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -621,6 +621,7 @@ type QueryParam struct {
 	FilterNodes []string            // A list of node names to restrict query to
 	FilterTags  map[string]string   // A map of tag name to regex to filter on
 	RequestAck  bool                // Should nodes ack the query receipt
+	RelayFactor uint8               // Duplicate response count to be relayed back to sender for redundancy.
 	Timeout     time.Duration       // Maximum query duration. Optional, will be set automatically.
 	Name        string              // Opaque query name
 	Payload     []byte              // Opaque query payload
@@ -643,6 +644,7 @@ func (c *RPCClient) Query(params *QueryParam) error {
 		FilterNodes: params.FilterNodes,
 		FilterTags:  params.FilterTags,
 		RequestAck:  params.RequestAck,
+		RelayFactor: params.RelayFactor,
 		Timeout:     params.Timeout,
 		Name:        params.Name,
 		Payload:     params.Payload,

--- a/cmd/serf/command/force_leave_test.go
+++ b/cmd/serf/command/force_leave_test.go
@@ -62,8 +62,12 @@ WAIT:
 		t.Fatalf("should have 2 members: %#v", a1.Serf().Members())
 	}
 
-	if m[1].Status != serf.StatusLeft {
-		t.Fatalf("should be left: %#v", m[1])
+	left := m[0]
+	if m[1].Name == a2.SerfConfig().NodeName {
+		left = m[1]
+	}
+	if left.Status != serf.StatusLeft {
+		t.Fatalf("should be left: %#v", left)
 	}
 }
 

--- a/cmd/serf/command/query_test.go
+++ b/cmd/serf/command/query_test.go
@@ -191,3 +191,34 @@ func TestQueryCommandRun_formatJSON(t *testing.T) {
 		t.Fatalf("bad: %#v", out)
 	}
 }
+
+func TestQueryCommandRun_invalidRelayFactor(t *testing.T) {
+	ui := new(cli.MockUi)
+	{
+		c := &QueryCommand{Ui: ui}
+		args := []string{"-rpc-addr=foo", "-relay-factor=9999", "foo"}
+
+		code := c.Run(args)
+		if code != 1 {
+			t.Fatalf("bad: %d", code)
+		}
+
+		if !strings.Contains(ui.ErrorWriter.String(), "Relay factor must be") {
+			t.Fatalf("bad: %#v", ui.ErrorWriter.String())
+		}
+	}
+
+	{
+		c := &QueryCommand{Ui: ui}
+		args := []string{"-rpc-addr=foo", "-relay-factor=-1", "foo"}
+
+		code := c.Run(args)
+		if code != 1 {
+			t.Fatalf("bad: %d", code)
+		}
+
+		if !strings.Contains(ui.ErrorWriter.String(), "Relay factor must be") {
+			t.Fatalf("bad: %#v", ui.ErrorWriter.String())
+		}
+	}
+}

--- a/serf/config.go
+++ b/serf/config.go
@@ -241,7 +241,7 @@ func DefaultConfig() *Config {
 		EventBuffer:                  512,
 		QueryBuffer:                  512,
 		LogOutput:                    os.Stderr,
-		ProtocolVersion:              ProtocolVersionMax,
+		ProtocolVersion:              4,
 		ReapInterval:                 15 * time.Second,
 		RecentIntentTimeout:          5 * time.Minute,
 		ReconnectInterval:            30 * time.Second,

--- a/serf/config.go
+++ b/serf/config.go
@@ -15,6 +15,7 @@ var ProtocolVersionMap map[uint8]uint8
 
 func init() {
 	ProtocolVersionMap = map[uint8]uint8{
+		5: 2,
 		4: 2,
 		3: 2,
 		2: 2,
@@ -164,6 +165,10 @@ type Config struct {
 	QueryResponseSizeLimit int
 	QuerySizeLimit         int
 
+	// QueryResponseRelayLimit controls the maximum number of nodes used to echo a
+	// query response back to the originator of the query
+	QueryResponseRelayLimit int
+
 	// MemberlistConfig is the memberlist configuration that Serf will
 	// use to do the underlying membership management and gossip. Some
 	// fields in the MemberlistConfig will be overwritten by Serf no
@@ -253,6 +258,7 @@ func DefaultConfig() *Config {
 		QueryTimeoutMult:             16,
 		QueryResponseSizeLimit:       1024,
 		QuerySizeLimit:               1024,
+		QueryResponseRelayLimit:      3,
 		EnableNameConflictResolution: true,
 		DisableCoordinates:           false,
 	}

--- a/serf/config.go
+++ b/serf/config.go
@@ -165,10 +165,6 @@ type Config struct {
 	QueryResponseSizeLimit int
 	QuerySizeLimit         int
 
-	// QueryResponseRelayLimit controls the maximum number of nodes used to echo a
-	// query response back to the originator of the query
-	QueryResponseRelayLimit int
-
 	// MemberlistConfig is the memberlist configuration that Serf will
 	// use to do the underlying membership management and gossip. Some
 	// fields in the MemberlistConfig will be overwritten by Serf no
@@ -258,7 +254,6 @@ func DefaultConfig() *Config {
 		QueryTimeoutMult:             16,
 		QueryResponseSizeLimit:       1024,
 		QuerySizeLimit:               1024,
-		QueryResponseRelayLimit:      3,
 		EnableNameConflictResolution: true,
 		DisableCoordinates:           false,
 	}

--- a/serf/config_test.go
+++ b/serf/config_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestDefaultConfig(t *testing.T) {
 	c := DefaultConfig()
-	if c.ProtocolVersion != ProtocolVersionMax {
+	if c.ProtocolVersion != 4 {
 		t.Fatalf("bad: %#v", c)
 	}
 }

--- a/serf/delegate.go
+++ b/serf/delegate.go
@@ -98,6 +98,7 @@ func (d *delegate) NotifyMsg(buf []byte) {
 		// The remaining contents are the message itself, so forward that
 		raw := make([]byte, reader.Len())
 		reader.Read(raw)
+		d.serf.logger.Printf("[DEBUG] serf: Relaying response to addr: %s", header.DestAddr.String())
 		if err := d.serf.memberlist.SendTo(&header.DestAddr, raw); err != nil {
 			d.serf.logger.Printf("[ERR] serf: Error forwarding message to %s: %s", header.DestAddr.String(), err)
 			break

--- a/serf/event.go
+++ b/serf/event.go
@@ -107,7 +107,7 @@ type Query struct {
 	addr        []byte    // Address to respond to
 	port        uint16    // Port to respond to
 	deadline    time.Time // Must respond by this deadline
-	relayFactor int       // Number of duplicate responses to relay back to sender
+	relayFactor uint8     // Number of duplicate responses to relay back to sender
 	respLock    sync.Mutex
 }
 
@@ -179,7 +179,7 @@ func (q *Query) Respond(buf []byte) error {
 			return fmt.Errorf("relayed response exceeds limit of %d bytes", q.serf.config.QueryResponseSizeLimit)
 		}
 
-		relayMembers := kRandomMembers(q.relayFactor, members, func(m Member) bool {
+		relayMembers := kRandomMembers(int(q.relayFactor), members, func(m Member) bool {
 			return m.Status != StatusAlive || m.ProtocolMax < 5 || m.Name == q.serf.LocalMember().Name
 		})
 

--- a/serf/event_test.go
+++ b/serf/event_test.go
@@ -1,6 +1,7 @@
 package serf
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -208,4 +209,59 @@ func TestEventType_String(t *testing.T) {
 		}
 	}()
 	other.String()
+}
+
+func TestKRandomNodes(t *testing.T) {
+	nodes := []Member{}
+	for i := 0; i < 90; i++ {
+		// Half the nodes are in a bad state
+		state := StatusAlive
+		switch i % 3 {
+		case 0:
+			state = StatusAlive
+		case 1:
+			state = StatusFailed
+		case 2:
+			state = StatusLeft
+		}
+		nodes = append(nodes, Member{
+			Name:   fmt.Sprintf("test%d", i),
+			Status: state,
+		})
+	}
+
+	filterFunc := func(m Member) bool {
+		if m.Name == "test0" || m.Status != StatusAlive {
+			return true
+		}
+		return false
+	}
+
+	s1 := kRandomMembers(3, nodes, filterFunc)
+	s2 := kRandomMembers(3, nodes, filterFunc)
+	s3 := kRandomMembers(3, nodes, filterFunc)
+
+	if reflect.DeepEqual(s1, s2) {
+		t.Fatalf("unexpected equal")
+	}
+	if reflect.DeepEqual(s1, s3) {
+		t.Fatalf("unexpected equal")
+	}
+	if reflect.DeepEqual(s2, s3) {
+		t.Fatalf("unexpected equal")
+	}
+
+	for _, s := range [][]Member{s1, s2, s3} {
+		if len(s) != 3 {
+			t.Fatalf("bad len")
+		}
+		for _, m := range s {
+			if m.Name == "test0" {
+				t.Fatalf("Bad name")
+			}
+			if m.Status != StatusAlive {
+				t.Fatalf("Bad state")
+			}
+		}
+	}
 }

--- a/serf/messages.go
+++ b/serf/messages.go
@@ -140,6 +140,7 @@ func encodeMessage(t messageType, msg interface{}) ([]byte, error) {
 	return buf.Bytes(), err
 }
 
+// relayHeader is used to store the end destination of a relayed message
 type relayHeader struct {
 	DestAddr net.UDPAddr
 }

--- a/serf/messages.go
+++ b/serf/messages.go
@@ -2,9 +2,10 @@ package serf
 
 import (
 	"bytes"
-	"github.com/hashicorp/go-msgpack/codec"
 	"net"
 	"time"
+
+	"github.com/hashicorp/go-msgpack/codec"
 )
 
 // messageType are the types of gossip messages Serf will send along
@@ -145,25 +146,17 @@ type relayHeader struct {
 // encodeRelayMessage wraps a message in the messageRelayType, adding the length and
 // address of the end recipient to the front of the message
 func encodeRelayMessage(t messageType, addr net.UDPAddr, msg interface{}) ([]byte, error) {
-	headerBuf := bytes.NewBuffer(nil)
-	headerHandle := codec.MsgpackHandle{}
-	headerEncoder := codec.NewEncoder(headerBuf, &headerHandle)
-
-	err := headerEncoder.Encode(relayHeader{DestAddr: addr})
-	if err != nil {
-		return nil, err
-	}
-
 	buf := bytes.NewBuffer(nil)
 	handle := codec.MsgpackHandle{}
 	encoder := codec.NewEncoder(buf, &handle)
 
 	buf.WriteByte(uint8(messageRelayType))
-	buf.WriteByte(uint8(len(headerBuf.Bytes())))
-	buf.Write(headerBuf.Bytes())
+	if err := encoder.Encode(relayHeader{DestAddr: addr}); err != nil {
+		return nil, err
+	}
 
 	buf.WriteByte(uint8(t))
-	err = encoder.Encode(msg)
+	err := encoder.Encode(msg)
 	return buf.Bytes(), err
 }
 

--- a/serf/messages.go
+++ b/serf/messages.go
@@ -78,15 +78,16 @@ type messageUserEvent struct {
 
 // messageQuery is used for query events
 type messageQuery struct {
-	LTime   LamportTime   // Event lamport time
-	ID      uint32        // Query ID, randomly generated
-	Addr    []byte        // Source address, used for a direct reply
-	Port    uint16        // Source port, used for a direct reply
-	Filters [][]byte      // Potential query filters
-	Flags   uint32        // Used to provide various flags
-	Timeout time.Duration // Maximum time between delivery and response
-	Name    string        // Query name
-	Payload []byte        // Query payload
+	LTime       LamportTime   // Event lamport time
+	ID          uint32        // Query ID, randomly generated
+	Addr        []byte        // Source address, used for a direct reply
+	Port        uint16        // Source port, used for a direct reply
+	Filters     [][]byte      // Potential query filters
+	Flags       uint32        // Used to provide various flags
+	RelayFactor uint8         // Used to set the number of duplicate relayed responses
+	Timeout     time.Duration // Maximum time between delivery and response
+	Name        string        // Query name
+	Payload     []byte        // Query payload
 }
 
 // Ack checks if the ack flag is set

--- a/serf/messages_test.go
+++ b/serf/messages_test.go
@@ -48,25 +48,21 @@ func TestEncodeRelayMessage(t *testing.T) {
 		t.Fatal("should have type header")
 	}
 
-	addrLen := int(raw[1])
-	if addrLen != len(addr.String()) {
-		t.Fatalf("bad: %d, %d", addrLen, len(addr.String()))
+	var header relayHeader
+	headerLen := int(raw[1])
+	if err := decodeMessage(raw[2:headerLen+2], &header); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(header.DestAddr, addr) {
+		t.Fatalf("bad: %v, %v", header.DestAddr, addr)
 	}
 
-	rawAddr, err := net.ResolveUDPAddr("udp", string(raw[2:addrLen+2]))
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if rawAddr.IP.String() != addr.IP.String() || rawAddr.Port != addr.Port {
-		t.Fatalf("bad: %v, %v", rawAddr, addr)
-	}
-
-	if raw[addrLen+2] != byte(messageLeaveType) {
+	if raw[headerLen+2] != byte(messageLeaveType) {
 		t.Fatal("should have type header")
 	}
 
 	var out messageLeave
-	if err := decodeMessage(raw[addrLen+3:], &out); err != nil {
+	if err := decodeMessage(raw[headerLen+3:], &out); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/serf/query.go
+++ b/serf/query.go
@@ -94,8 +94,8 @@ type QueryResponse struct {
 	respCh chan NodeResponse
 
 	// acks/responses are used to track the nodes that have sent an ack/response
-	acks      map[string]bool
-	responses map[string]bool
+	acks      map[string]struct{}
+	responses map[string]struct{}
 
 	closed    bool
 	closeLock sync.Mutex
@@ -108,11 +108,11 @@ func newQueryResponse(n int, q *messageQuery) *QueryResponse {
 		id:        q.ID,
 		lTime:     q.LTime,
 		respCh:    make(chan NodeResponse, n),
-		responses: make(map[string]bool),
+		responses: make(map[string]struct{}),
 	}
 	if q.Ack() {
 		resp.ackCh = make(chan string, n)
-		resp.acks = make(map[string]bool)
+		resp.acks = make(map[string]struct{})
 	}
 	return resp
 }

--- a/serf/query.go
+++ b/serf/query.go
@@ -45,12 +45,10 @@ func (s *Serf) DefaultQueryTimeout() time.Duration {
 
 // DefaultQueryParam is used to return the default query parameters
 func (s *Serf) DefaultQueryParams() *QueryParam {
-	relayFactor := math.Ceil(math.Log10(float64(s.memberlist.NumMembers() + 1)))
 	return &QueryParam{
 		FilterNodes: nil,
 		FilterTags:  nil,
 		RequestAck:  false,
-		RelayFactor: uint8(relayFactor),
 		Timeout:     s.DefaultQueryTimeout(),
 	}
 }

--- a/serf/query.go
+++ b/serf/query.go
@@ -93,6 +93,10 @@ type QueryResponse struct {
 	// respCh is used to send a response from a node
 	respCh chan NodeResponse
 
+	// acks/responses are used to track the nodes that have sent an ack/response
+	acks      map[string]bool
+	responses map[string]bool
+
 	closed    bool
 	closeLock sync.Mutex
 }
@@ -100,13 +104,15 @@ type QueryResponse struct {
 // newQueryResponse is used to construct a new query response
 func newQueryResponse(n int, q *messageQuery) *QueryResponse {
 	resp := &QueryResponse{
-		deadline: time.Now().Add(q.Timeout),
-		id:       q.ID,
-		lTime:    q.LTime,
-		respCh:   make(chan NodeResponse, n),
+		deadline:  time.Now().Add(q.Timeout),
+		id:        q.ID,
+		lTime:     q.LTime,
+		respCh:    make(chan NodeResponse, n),
+		responses: make(map[string]bool),
 	}
 	if q.Ack() {
 		resp.ackCh = make(chan string, n)
+		resp.acks = make(map[string]bool)
 	}
 	return resp
 }

--- a/serf/query.go
+++ b/serf/query.go
@@ -24,6 +24,10 @@ type QueryParam struct {
 	// send an ack.
 	RequestAck bool
 
+	// RelayFactor controls the number of duplicate responses to relay
+	// back to the sender through other nodes for redundancy.
+	RelayFactor uint8
+
 	// The timeout limits how long the query is left open. If not provided,
 	// then a default timeout is used based on the configuration of Serf
 	Timeout time.Duration
@@ -41,10 +45,12 @@ func (s *Serf) DefaultQueryTimeout() time.Duration {
 
 // DefaultQueryParam is used to return the default query parameters
 func (s *Serf) DefaultQueryParams() *QueryParam {
+	relayFactor := math.Ceil(math.Log10(float64(s.memberlist.NumMembers() + 1)))
 	return &QueryParam{
 		FilterNodes: nil,
 		FilterTags:  nil,
 		RequestAck:  false,
+		RelayFactor: uint8(relayFactor),
 		Timeout:     s.DefaultQueryTimeout(),
 	}
 }

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -1242,14 +1242,14 @@ func (s *Serf) handleQuery(query *messageQuery) bool {
 
 	if s.config.EventCh != nil {
 		s.config.EventCh <- &Query{
-			LTime:    query.LTime,
-			Name:     query.Name,
-			Payload:  query.Payload,
-			serf:     s,
-			id:       query.ID,
-			addr:     query.Addr,
-			port:     query.Port,
-			deadline: time.Now().Add(query.Timeout),
+			LTime:       query.LTime,
+			Name:        query.Name,
+			Payload:     query.Payload,
+			serf:        s,
+			id:          query.ID,
+			addr:        query.Addr,
+			port:        query.Port,
+			deadline:    time.Now().Add(query.Timeout),
 			relayFactor: s.config.QueryResponseRelayLimit,
 		}
 	}

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -499,15 +499,16 @@ func (s *Serf) Query(name string, payload []byte, params *QueryParam) (*QueryRes
 
 	// Create a message
 	q := messageQuery{
-		LTime:   s.queryClock.Time(),
-		ID:      uint32(rand.Int31()),
-		Addr:    local.Addr,
-		Port:    local.Port,
-		Filters: filters,
-		Flags:   flags,
-		Timeout: params.Timeout,
-		Name:    name,
-		Payload: payload,
+		LTime:       s.queryClock.Time(),
+		ID:          uint32(rand.Int31()),
+		Addr:        local.Addr,
+		Port:        local.Port,
+		Filters:     filters,
+		Flags:       flags,
+		RelayFactor: params.RelayFactor,
+		Timeout:     params.Timeout,
+		Name:        name,
+		Payload:     payload,
 	}
 
 	// Encode the query
@@ -1250,7 +1251,7 @@ func (s *Serf) handleQuery(query *messageQuery) bool {
 			addr:        query.Addr,
 			port:        query.Port,
 			deadline:    time.Now().Add(query.Timeout),
-			relayFactor: s.config.QueryResponseRelayLimit,
+			relayFactor: query.RelayFactor,
 		}
 	}
 	return rebroadcast

--- a/website/source/docs/commands/query.html.markdown
+++ b/website/source/docs/commands/query.html.markdown
@@ -51,6 +51,9 @@ The command-line flags are all optional. The list of available flags are:
   will acknowledge receipt of a query and potentially respond if they have a configured
   event handler.
 
+* `-relay-factor` - If provided, nodes responding to the query will relay their response
+  through the specified number of other nodes for redundancy. Must be between 0 and 255.
+
 * `-node node` - If provided, output is filtered to only nodes with the given
   node name. `-node` can be specified multiple times to allow multiple nodes.
 


### PR DESCRIPTION
Adds messageRelayType for sending query responses through multiple (defaults to 3 for now) randomly chosen nodes for robustness.