### PR TITLE
Remove the execute flag from the created snapshot files

### DIFF
--- a/serf/snapshot.go
+++ b/serf/snapshot.go
@@ -84,7 +84,7 @@ func NewSnapshotter(path string,
 	inCh := make(chan Event, 1024)
 
 	// Try to open the file
-	fh, err := os.OpenFile(path, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0755)
+	fh, err := os.OpenFile(path, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0644)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to open snapshot: %v", err)
 	}


### PR DESCRIPTION
Unless I am unaware of some odd feature there is no need to set the execute bit on the file permissions of created snapshot files. 