### PR TITLE
Fix a few races around the QueryResponse

### DIFF
--- a/serf/query.go
+++ b/serf/query.go
@@ -1,6 +1,7 @@
 package serf
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -148,6 +149,8 @@ func (r *QueryResponse) Deadline() time.Time {
 
 // Finished returns if the query is finished running
 func (r *QueryResponse) Finished() bool {
+	r.closeLock.Lock()
+	defer r.closeLock.Unlock()
 	return r.closed || time.Now().After(r.deadline)
 }
 
@@ -162,6 +165,22 @@ func (r *QueryResponse) AckCh() <-chan string {
 // Channel will be closed when the query is finished.
 func (r *QueryResponse) ResponseCh() <-chan NodeResponse {
 	return r.respCh
+}
+
+// sendResponse sends a response on the response channel ensuring the channel is not closed.
+func (r *QueryResponse) sendResponse(nr NodeResponse) error {
+	r.closeLock.Lock()
+	defer r.closeLock.Unlock()
+	if r.closed {
+		return nil
+	}
+	select {
+	case r.respCh <- nr:
+		r.responses[nr.From] = struct{}{}
+	default:
+		return errors.New("serf: Failed to deliver query response, dropping")
+	}
+	return nil
 }
 
 // NodeResponse is used to represent a single response from a node

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -1319,11 +1319,9 @@ func (s *Serf) handleQueryResponse(resp *messageQueryResponse) {
 		}
 
 		metrics.IncrCounter([]string{"serf", "query_responses"}, 1)
-		select {
-		case query.respCh <- NodeResponse{From: resp.From, Payload: resp.Payload}:
-			query.responses[resp.From] = struct{}{}
-		default:
-			s.logger.Printf("[WARN] serf: Failed to deliver query response, dropping")
+		err := query.sendResponse(NodeResponse{From: resp.From, Payload: resp.Payload})
+		if err != nil {
+			s.logger.Printf("[WARN] %v", err)
 		}
 	}
 }


### PR DESCRIPTION
There were two races in the QueryResponse type:

1. In the Finished method the read on r.closed needs to be protected
2. When sending the response on the channel a check needs to be made if the channel has been closed while holding the lock.

Both of these races have been fixed with this PR.