### PR TITLE
Handles the panic for eventJoinIgnore data-race state.

### DIFF
--- a/serf/delegate.go
+++ b/serf/delegate.go
@@ -248,10 +248,10 @@ func (d *delegate) MergeRemoteState(buf []byte, isJoin bool) {
 		d.serf.handleNodeJoinIntent(&join)
 	}
 
-	// If we are doing a join, and eventJoinIgnore is set
+	// If we are doing a join, and EventJoinIgnore() is set
 	// then we set the eventMinTime to the EventLTime. This
 	// prevents any of the incoming events from being processed
-	if isJoin && d.serf.eventJoinIgnore {
+	if isJoin && d.serf.EventJoinIgnore() {
 		d.serf.eventLock.Lock()
 		if pp.EventLTime > d.serf.eventMinTime {
 			d.serf.eventMinTime = pp.EventLTime


### PR DESCRIPTION
### Summary
There exists an unsynchronized read within the `delegate.go` file where a data-race was identified by another user.

- [x] - closes https://github.com/hashicorp/serf/issues/435
- [x] - moves the `joinLock` mutex above the `eventJoinIgnore` field of which it protects.
- [x] - in the `Serf.Join` function moves to fine-grained locking to avoid a dead-lock scenario.
- [x] - exposes an exported function called: `EventJoinIgnore` which locks and returns a copy of the state of the boolean. 
- [x] - refactors the `delegate.MergeRemoteState` method to get the `eventJoinIgnore` bool state only through the newly exposed public method.