### PR TITLE
Fix data race on eventJoinIgnore

### DIFF
--- a/serf/delegate.go
+++ b/serf/delegate.go
@@ -251,7 +251,8 @@ func (d *delegate) MergeRemoteState(buf []byte, isJoin bool) {
 	// If we are doing a join, and eventJoinIgnore is set
 	// then we set the eventMinTime to the EventLTime. This
 	// prevents any of the incoming events from being processed
-	if isJoin && d.serf.eventJoinIgnore {
+	eventJoinIgnore := d.serf.eventJoinIgnore.Load().(bool)
+	if isJoin && eventJoinIgnore {
 		d.serf.eventLock.Lock()
 		if pp.EventLTime > d.serf.eventMinTime {
 			d.serf.eventMinTime = pp.EventLTime


### PR DESCRIPTION
eventJoinIgnore is read and written in two different places
but access is not synchronized. Using the joinLock on read
blocks progress.