### PR TITLE
Snapshot write fail recover

### DIFF
--- a/serf/snapshot.go
+++ b/serf/snapshot.go
@@ -31,6 +31,7 @@ const flushInterval = 500 * time.Millisecond
 const clockUpdateInterval = 500 * time.Millisecond
 const coordinateUpdateInterval = 60 * time.Second
 const tmpExt = ".compact"
+const snapshotErrorRecoveryInterval = 30 * time.Second
 
 // Snapshotter is responsible for ingesting events and persisting
 // them to disk, and providing a recovery mechanism at start time.
@@ -55,6 +56,7 @@ type Snapshotter struct {
 	rejoinAfterLeave bool
 	shutdownCh       <-chan struct{}
 	waitCh           chan struct{}
+	lastAttemptedCompaction        time.Time
 }
 
 // PreviousNode is used to represent the previously known alive nodes
@@ -311,6 +313,18 @@ func (s *Snapshotter) processQuery(q *Query) {
 func (s *Snapshotter) tryAppend(l string) {
 	if err := s.appendLine(l); err != nil {
 		s.logger.Printf("[ERR] serf: Failed to update snapshot: %v", err)
+		now := time.Now()
+		if now.Sub(s.lastAttemptedCompaction) > snapshotErrorRecoveryInterval {
+			s.lastAttemptedCompaction = now
+			wrErr := err
+			s.logger.Printf("[ERR] serf: Attempting compaction to recover from error...")
+			err = s.compact()
+			if err != nil {
+				s.logger.Printf("[ERR] serf: Failed compaction due to error %v, will reattempt in %v", err, snapshotErrorRecoveryInterval)
+			} else {
+				s.logger.Printf("[INFO] serf: Finished compaction, successfully recovered from error state %q", wrErr)
+			}
+		}
 	}
 }
 
@@ -320,16 +334,7 @@ func (s *Snapshotter) appendLine(l string) error {
 
 	n, err := s.buffered.WriteString(l)
 	if err != nil {
-		wrErr := err
-        s.logger.Printf("[ERR] serf: Failed to write to snapshot file due to error: %v, attempting compaction...", err)
-		err = s.compact()
-		if err != nil {
-			s.logger.Printf("[ERR] serf: Failed compaction due to error %v, check if you are out of disk space?", err)
-			return err
-		} else {
-			s.logger.Printf("[INFO] serf: Finished compaction to recover from error state %v", wrErr)
-			return nil
-		}
+		return err
 	}
 
 	// Check if we should flush

--- a/serf/snapshot.go
+++ b/serf/snapshot.go
@@ -320,13 +320,14 @@ func (s *Snapshotter) appendLine(l string) error {
 
 	n, err := s.buffered.WriteString(l)
 	if err != nil {
+		wrErr := err
         s.logger.Printf("[ERR] serf: Failed to write to snapshot file due to error: %v, attempting compaction...", err)
 		err = s.compact()
 		if err != nil {
 			s.logger.Printf("[ERR] serf: Failed compaction due to error %v, check if you are out of disk space?", err)
 			return err
 		} else {
-			s.logger.Println("[INFO] serf: Finished compaction")
+			s.logger.Printf("[INFO] serf: Finished compaction to recover from error state %v", wrErr)
 			return nil
 		}
 	}

--- a/serf/snapshot.go
+++ b/serf/snapshot.go
@@ -316,13 +316,12 @@ func (s *Snapshotter) tryAppend(l string) {
 		now := time.Now()
 		if now.Sub(s.lastAttemptedCompaction) > snapshotErrorRecoveryInterval {
 			s.lastAttemptedCompaction = now
-			wrErr := err
-			s.logger.Printf("[ERR] serf: Attempting compaction to recover from error...")
+			s.logger.Printf("[INFO] serf: Attempting compaction to recover from error...")
 			err = s.compact()
 			if err != nil {
-				s.logger.Printf("[ERR] serf: Failed compaction due to error %v, will reattempt in %v", err, snapshotErrorRecoveryInterval)
+				s.logger.Printf("[ERR] serf: Compaction failed, will reattempt after %v: %v", snapshotErrorRecoveryInterval, err)
 			} else {
-				s.logger.Printf("[INFO] serf: Finished compaction, successfully recovered from error state %q", wrErr)
+				s.logger.Printf("[INFO] serf: Finished compaction, successfully recovered from error state")
 			}
 		}
 	}

--- a/serf/snapshot.go
+++ b/serf/snapshot.go
@@ -320,7 +320,15 @@ func (s *Snapshotter) appendLine(l string) error {
 
 	n, err := s.buffered.WriteString(l)
 	if err != nil {
-		return err
+        s.logger.Printf("[ERR] serf: Failed to write to snapshot file due to error: %v, attempting compaction...", err)
+		err = s.compact()
+		if err != nil {
+			s.logger.Printf("[ERR] serf: Failed compaction due to error %v, check if you are out of disk space?", err)
+			return err
+		} else {
+			s.logger.Println("[INFO] serf: Finished compaction")
+			return nil
+		}
 	}
 
 	// Check if we should flush


### PR DESCRIPTION
This attempts a compaction every 30 seconds after an error when appending to the snapshot file (both local and remote). After this is merged we should be able to gracefully recover from disk availability or other intermittent write errors without needing a restart.

This fixes #477