### PR TITLE
Fix Serf.Stats() panic when coordinates are disabled

### DIFF
--- a/serf/serf.go
+++ b/serf/serf.go
@@ -1655,18 +1655,20 @@ func (s *Serf) Stats() map[string]string {
 		return strconv.FormatUint(v, 10)
 	}
 	stats := map[string]string{
-		"members":           toString(uint64(len(s.members))),
-		"failed":            toString(uint64(len(s.failedMembers))),
-		"left":              toString(uint64(len(s.leftMembers))),
-		"health_score":      toString(uint64(s.memberlist.GetHealthScore())),
-		"member_time":       toString(uint64(s.clock.Time())),
-		"event_time":        toString(uint64(s.eventClock.Time())),
-		"query_time":        toString(uint64(s.queryClock.Time())),
-		"intent_queue":      toString(uint64(s.broadcasts.NumQueued())),
-		"event_queue":       toString(uint64(s.eventBroadcasts.NumQueued())),
-		"query_queue":       toString(uint64(s.queryBroadcasts.NumQueued())),
-		"encrypted":         fmt.Sprintf("%v", s.EncryptionEnabled()),
-		"coordinate_resets": toString(uint64(s.coordClient.Stats().Resets)),
+		"members":      toString(uint64(len(s.members))),
+		"failed":       toString(uint64(len(s.failedMembers))),
+		"left":         toString(uint64(len(s.leftMembers))),
+		"health_score": toString(uint64(s.memberlist.GetHealthScore())),
+		"member_time":  toString(uint64(s.clock.Time())),
+		"event_time":   toString(uint64(s.eventClock.Time())),
+		"query_time":   toString(uint64(s.queryClock.Time())),
+		"intent_queue": toString(uint64(s.broadcasts.NumQueued())),
+		"event_queue":  toString(uint64(s.eventBroadcasts.NumQueued())),
+		"query_queue":  toString(uint64(s.queryBroadcasts.NumQueued())),
+		"encrypted":    fmt.Sprintf("%v", s.EncryptionEnabled()),
+	}
+	if !s.config.DisableCoordinates {
+		stats["coordinate_resets"] = toString(uint64(s.coordClient.Stats().Resets))
 	}
 	return stats
 }


### PR DESCRIPTION
If the Serf agent is configured with coordinates disabled (i.e. `serf.Config.DisabledCoordinates = true`), invoking `Serf.Stats()` causes a segmentation fault. That's because, in order to set the value of `"coordinate_resets"` in the stats map, `Serf.Stats()` invokes `s.coordClient.Stats()`, with `s.coordClient `being a nil pointer.

This pull request fixes this issue by setting the value of `"coordinate_resets"` in the stats map only if coordinates are enabled.