### PR TITLE
Suppress WSARecv error by case-insensitive match

### DIFF
--- a/cmd/serf/command/agent/ipc.go
+++ b/cmd/serf/command/agent/ipc.go
@@ -435,7 +435,7 @@ func (i *AgentIPC) handleClient(client *IPCClient) {
 				// The second part of this if is to block socket
 				// errors from Windows which appear to happen every
 				// time there is an EOF.
-				if err != io.EOF && !strings.Contains(err.Error(), "WSARecv") {
+				if err != io.EOF && !strings.Contains(strings.ToLower(err.Error()), "wsarecv") {
 					i.logger.Printf("[ERR] agent.ipc: failed to decode request header: %v", err)
 				}
 			}


### PR DESCRIPTION
On Windows, Serf outputs a WSARecv error message every time when it
receives a client IPC request.

Its code seems to try to suppress such an error message but it just
matches "WSARecv" word against an error message though the actual one
only has a lower case "wsarecv" word in recent Go implementation.

This fixes it by comparing a lower cased error message with "wsarecv",
in other words, doing case-insensitive match.

---
Here is the actual error message example

```
2017/07/10 18:46:00 [ERR] agent.ipc: failed to decode request header: read tcp 127.0.0.1:7373->127.0.0.1:50390: wsarecv: An existing connection was forcibly closed by the remote host.
```

and "wsarecv" lower cased word seems to come from ﻿https://github.com/golang/go/commit/055ecb7be5805e07498488c59c6f01644fdacccc#diff-035f0453152e3560da9e8c1b00500a09R469