### PR TITLE
Protect against ping periods that are out of range

### DIFF
--- a/coordinate/client.go
+++ b/coordinate/client.go
@@ -8,8 +8,6 @@ import (
 	"time"
 )
 
-const MAX_RTT_SECONDS = 32400 //9 hours is the upper bound for ping period
-
 // Client manages the estimated network coordinate for a given node, and adjusts
 // it as the node observes round trip times and estimated coordinates from other
 // nodes. The core algorithm is based on Vivaldi, see the documentation for Config
@@ -207,9 +205,9 @@ func (c *Client) Update(node string, other *Coordinate, rtt time.Duration) (*Coo
 		return nil, err
 	}
 
-	durSec := rtt.Seconds()
-	if durSec <= 0 || durSec > MAX_RTT_SECONDS {
-		return nil, fmt.Errorf("Round trip time not in valid range, duration %v is not a positive value less than %v ", durSec, MAX_RTT_SECONDS)
+	const maxRTT = 10 * time.Second
+	if rtt <= 0 || rtt > maxRTT {
+		return nil, fmt.Errorf("round trip time not in valid range, duration %v is not a positive value less than %v ", rtt, maxRTT)
 	}
 
 	rttSeconds := c.latencyFilter(node, rtt.Seconds())

--- a/coordinate/client.go
+++ b/coordinate/client.go
@@ -8,6 +8,8 @@ import (
 	"time"
 )
 
+const MAX_RTT_SECONDS = 32400 //9 hours is the upper bound for ping period
+
 // Client manages the estimated network coordinate for a given node, and adjusts
 // it as the node observes round trip times and estimated coordinates from other
 // nodes. The core algorithm is based on Vivaldi, see the documentation for Config
@@ -203,6 +205,11 @@ func (c *Client) Update(node string, other *Coordinate, rtt time.Duration) (*Coo
 
 	if err := c.checkCoordinate(other); err != nil {
 		return nil, err
+	}
+
+	durSec := rtt.Seconds()
+	if durSec <= 0 || durSec > MAX_RTT_SECONDS {
+		return nil, fmt.Errorf("Round trip time not in valid range, duration %v is not a positive value less than %v ", durSec, MAX_RTT_SECONDS)
 	}
 
 	rttSeconds := c.latencyFilter(node, rtt.Seconds())

--- a/coordinate/client_test.go
+++ b/coordinate/client_test.go
@@ -74,46 +74,24 @@ func TestClient_InvalidInPingValues(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Make sure the Euclidean part of our coordinate is what we expect.
-	c := client.GetCoordinate()
-	verifyEqualVectors(t, c.Vec, []float64{0.0, 0.0, 0.0})
-
 	// Place another node
 	other := NewCoordinate(config)
 	other.Vec[2] = 0.001
-	rtt := time.Duration(2.0 * other.Vec[2] * secondsToNanoseconds)
-	c, err = client.Update("node", other, rtt)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	dist_old := client.DistanceTo(other)
-	// Update with a valid ping period, should have an affect on estimated rtt
-	ping := 20
-	_, err = client.Update("node", other, time.Duration(ping*secondsToNanoseconds))
-	if err != nil {
-		t.Fatalf("Unexpected error ", err)
-	}
-
-	dist_new := client.DistanceTo(other)
-	if dist_new <= dist_old {
-		t.Fatalf("Invalid rtt estimate %v", dist_new)
-	}
+	dist := client.DistanceTo(other)
 
 	// Update with a series of invalid ping periods, should return an error and estimated rtt remains unchanged
-	pings := []int{1<<63 - 1, -35, -1 << 63, 35000}
-	dist_old = dist_new
+	pings := []int{1<<63 - 1, -35, 11}
 
 	for _, ping := range pings {
-		expectedErr := fmt.Errorf("Round trip time not in valid range, duration %v is not a positive value less than %v", ping, MAX_RTT_SECONDS)
+		expectedErr := fmt.Errorf("round trip time not in valid range, duration %v is not a positive value less than %v", ping, 10*time.Second)
 		_, err = client.Update("node", other, time.Duration(ping*secondsToNanoseconds))
 		if err == nil {
 			t.Fatalf("Unexpected error, wanted %v but got %v", expectedErr, err)
 		}
 
-		dist_new = client.DistanceTo(other)
-		if dist_new != dist_old {
-			t.Fatalf("distance est", dist_new)
+		dist_new := client.DistanceTo(other)
+		if dist_new != dist {
+			t.Fatalf("distance estimate %v not equal to %v", dist_new, dist)
 		}
 	}
 


### PR DESCRIPTION
I could reliably reproduce both extreme negative adjustment values and negative rtt estimates by feeding it time.maxvalue as the rtt value, which is a valid return values from the `time.Sub` method. 

This patch makes it so that we reject any updates that contain rtt durations that are not in a range from 1 to 32400 seconds (9 hours). Another option is to force updates > 9 hrs to be = 9hrs, but rejecting it seemed better to avoid corrupted data feeding into the algorithm.

The 32000 was something I found from some experimentation with Vivaldi starting with two sets of coordinates at the origin and trying to get them to drift to the point where adjustment becomes this large negative value. 9 hours also seems like a conservative but large enough upper bound on the previously unbounded rtt value. 
