### PR TITLE
Homebrew no longer uses cask to install serf

### DIFF
--- a/website/source/intro/getting-started/install.html.markdown
+++ b/website/source/intro/getting-started/install.html.markdown
@@ -29,12 +29,7 @@ release.
 If you are using [homebrew](http://brew.sh/#install) as a package manager,
 than you can install serf as simple as:
 ```
-brew cask install serf
-```
-
-if you are missing the [cask plugin](http://caskroom.io/) you can install it with:
-```
-brew install caskroom/cask/brew-cask
+brew install serf
 ```
 
 ## Verifying the Installation


### PR DESCRIPTION
```
$ brew search serf
==> Searching local taps...
serf
==> Searching taps on GitHub...
==> Searching blacklisted, migrated and deleted formulae...

If you meant "serf" specifically:
It was migrated from caskroom/cask to homebrew/core.
```