### PR TITLE
Prevents log spam from zero RTTs.

### DIFF
--- a/coordinate/client.go
+++ b/coordinate/client.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/armon/go-metrics"
 )
 
 // Client manages the estimated network coordinate for a given node, and adjusts
@@ -205,9 +207,18 @@ func (c *Client) Update(node string, other *Coordinate, rtt time.Duration) (*Coo
 		return nil, err
 	}
 
+	// The code down below can handle zero RTTs, which we have seen in
+	// https://github.com/hashicorp/consul/issues/3789, presumably in
+	// environments with coarse-grained monotonic clocks (we are still
+	// trying to pin this down). In any event, this is ok from a code PoV
+	// so we don't need to alert operators with spammy messages. We did
+	// add a counter so this is still observable, though.
 	const maxRTT = 10 * time.Second
-	if rtt <= 0 || rtt > maxRTT {
+	if rtt < 0 || rtt > maxRTT {
 		return nil, fmt.Errorf("round trip time not in valid range, duration %v is not a positive value less than %v ", rtt, maxRTT)
+	}
+	if rtt == 0 {
+		metrics.IncrCounter([]string{"serf", "coordinate", "zero-rtt"}, 1)
 	}
 
 	rttSeconds := c.latencyFilter(node, rtt.Seconds())

--- a/serf/ping_delegate.go
+++ b/serf/ping_delegate.go
@@ -68,7 +68,8 @@ func (p *pingDelegate) NotifyPingComplete(other *memberlist.Node, rtt time.Durat
 	before := p.serf.coordClient.GetCoordinate()
 	after, err := p.serf.coordClient.Update(other.Name, &coord, rtt)
 	if err != nil {
-		p.serf.logger.Printf("[ERR] serf: Rejected coordinate from %s: %v\n",
+		metrics.IncrCounter([]string{"serf", "coordinate", "rejected"}, 1)
+		p.serf.logger.Printf("[TRACE] serf: Rejected coordinate from %s: %v\n",
 			other.Name, err)
 		return
 	}


### PR DESCRIPTION
These aren't harmful to the Vivaldi algorithm since we have a min 1 us RTT we use when this happens, so it's not worth logging them. We added a counter so we can still observe these, since we don't have a great root cause story on why we see them, other than a guess that some systems have a low monotonic clock granularity.

We also added a new metric for rejected coordinates and moved the detailed message to the TRACE level.

This is a fix for https://github.com/hashicorp/consul/issues/3789.