### PR TITLE
check node cluster membership before force leaving

### DIFF
--- a/client/const.go
+++ b/client/const.go
@@ -92,6 +92,10 @@ type forceLeaveRequest struct {
 	Node string
 }
 
+type forceLeaveResponse struct {
+	Exists bool
+}
+
 type joinRequest struct {
 	Existing []string
 	Replay   bool

--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -186,7 +186,7 @@ func (c *RPCClient) Close() error {
 
 // ForceLeave is used to ask the agent to issue a leave command for
 // a given node
-func (c *RPCClient) ForceLeave(node string) error {
+func (c *RPCClient) ForceLeave(node string) (bool, error) {
 	header := requestHeader{
 		Command: forceLeaveCommand,
 		Seq:     c.getSeq(),
@@ -194,7 +194,9 @@ func (c *RPCClient) ForceLeave(node string) error {
 	req := forceLeaveRequest{
 		Node: node,
 	}
-	return c.genericRPC(&header, &req, nil)
+	var resp forceLeaveResponse
+	err := c.genericRPC(&header, &req, &resp)
+	return resp.Exists, err
 }
 
 // Join is used to instruct the agent to attempt a join

--- a/cmd/serf/command/agent/agent.go
+++ b/cmd/serf/command/agent/agent.go
@@ -172,13 +172,16 @@ func (a *Agent) Join(addrs []string, replay bool) (n int, err error) {
 }
 
 // ForceLeave is used to eject a failed node from the cluster
-func (a *Agent) ForceLeave(node string) error {
+func (a *Agent) ForceLeave(node string) (bool, error) {
 	a.logger.Printf("[INFO] agent: Force leaving node: %s", node)
-	err := a.serf.RemoveFailedNode(node)
+	exists, err := a.serf.CheckAndRemoveFailedNode(node)
 	if err != nil {
 		a.logger.Printf("[WARN] agent: failed to remove node: %v", err)
 	}
-	return err
+	if !exists {
+		a.logger.Printf("[INFO] agent: Cannot force leave node that does not exist in the cluster: %s", node)
+	}
+	return exists, err
 }
 
 // UserEvent sends a UserEvent on Serf, see Serf.UserEvent.

--- a/cmd/serf/command/agent/ipc.go
+++ b/cmd/serf/command/agent/ipc.go
@@ -126,6 +126,10 @@ type forceLeaveRequest struct {
 	Node string
 }
 
+type forceLeaveResponse struct {
+	Exists bool
+}
+
 type joinRequest struct {
 	Existing []string
 	Replay   bool
@@ -604,14 +608,17 @@ func (i *AgentIPC) handleForceLeave(client *IPCClient, seq uint64) error {
 	}
 
 	// Attempt leave
-	err := i.agent.ForceLeave(req.Node)
+	exists, err := i.agent.ForceLeave(req.Node)
 
 	// Respond
-	resp := responseHeader{
+	header := responseHeader{
 		Seq:   seq,
 		Error: errToString(err),
 	}
-	return client.Send(&resp, nil)
+	resp := forceLeaveResponse{
+		Exists: exists,
+	}
+	return client.Send(&header, &resp)
 }
 
 func (i *AgentIPC) handleJoin(client *IPCClient, seq uint64) error {

--- a/cmd/serf/command/agent/rpc_client_test.go
+++ b/cmd/serf/command/agent/rpc_client_test.go
@@ -95,7 +95,7 @@ WAIT:
 		goto WAIT
 	}
 
-	if err := client.ForceLeave(a2.conf.NodeName); err != nil {
+	if _, err := client.ForceLeave(a2.conf.NodeName); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -108,6 +108,14 @@ WAIT:
 
 	if findMember(t, m, a2.conf.NodeName).Status != serf.StatusLeft {
 		t.Fatalf("should be left: %#v", m[1])
+	}
+
+	exists, err := client.ForceLeave("idontexist")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if exists {
+		t.Fatal("tried to remove a node that does not exists in the cluster, but got back that it exists in the cluster")
 	}
 }
 
@@ -275,7 +283,7 @@ func TestRPCClientMembersFiltered(t *testing.T) {
 	}
 
 	// Make sure that filters work on member status
-	if err := client.ForceLeave(a2.conf.NodeName); err != nil {
+	if _, err := client.ForceLeave(a2.conf.NodeName); err != nil {
 		t.Fatalf("bad: %s", err)
 	}
 

--- a/cmd/serf/command/force_leave.go
+++ b/cmd/serf/command/force_leave.go
@@ -37,10 +37,13 @@ func (c *ForceLeaveCommand) Run(args []string) int {
 	}
 	defer client.Close()
 
-	err = client.ForceLeave(nodes[0])
+	exists, err := client.ForceLeave(nodes[0])
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error force leaving: %s", err))
 		return 1
+	}
+	if !exists {
+		c.Ui.Info("Node does not exist in cluster.")
 	}
 
 	return 0
@@ -59,7 +62,8 @@ Usage: serf force-leave [options] name
   the cluster. This command is most useful for cleaning out "failed" nodes
   that are never coming back. If you do not force leave a failed node,
   Serf will attempt to reconnect to those failed nodes for some period of
-  time before eventually reaping them.
+  time before eventually reaping them. If you try to remove a node that
+  does not exist in the cluster it will let you know.
 
 Options:
 

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -741,6 +741,19 @@ func (s *Serf) Members() []Member {
 	return members
 }
 
+// CheckAndRemoveFailedNode checks if a node exists and then forcibly removes
+// the node via RemoveFailedNode. If the node does not exist in the cluster, it
+// will return exists as false and will not try to remove the node
+func (s *Serf) CheckAndRemoveFailedNode(node string) (exists bool, err error) {
+	// Check to make sure that the node exists in the cluster
+	_, ok := s.members[node]
+	if !ok {
+		return false, nil
+	}
+
+	return true, s.RemoveFailedNode(node)
+}
+
 // RemoveFailedNode forcibly removes a failed node from the cluster
 // immediately, instead of waiting for the reaper to eventually reclaim it.
 // This also has the effect that Serf will no longer attempt to reconnect

--- a/serf/serf_test.go
+++ b/serf/serf_test.go
@@ -831,6 +831,15 @@ func TestSerfRemoveFailedNode(t *testing.T) {
 	// Verify that s2 is gone
 	testMember(t, s1.Members(), s2Config.NodeName, StatusLeft)
 	testMember(t, s3.Members(), s2Config.NodeName, StatusLeft)
+
+	// try to force the shutdown of a node that is not a member
+	exists, err := s1.CheckAndRemoveFailedNode("idontexist")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if exists {
+		t.Fatal("tried to remove a node that does not exists in the cluster, but got back that it exists in the cluster")
+	}
 }
 
 func TestSerfRemoveFailedNode_ourself(t *testing.T) {
@@ -843,7 +852,7 @@ func TestSerfRemoveFailedNode_ourself(t *testing.T) {
 
 	testutil.Yield()
 
-	if err := s1.RemoveFailedNode("somebody"); err != nil {
+	if err := s1.RemoveFailedNode(s1Config.NodeName); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 }


### PR DESCRIPTION
This is for issue #500.

The core of this is to add a new function CheckAndRemoveFailedNode which checks if a node is a member of the cluster before removing it. I opted to create a new function so as not to break compatability with Consul. Once this gets approval I can update the functionality in Consul.