### PR TITLE
Make ForceLeave and RemoveFailedNode fail when node doesn't exist

### DIFF
--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -203,7 +202,7 @@ func (c *RPCClient) ForceLeave(node string) error {
 	}
 
 	if !found {
-		return errors.New(fmt.Sprintf("couldn't find node %s", node))
+		return fmt.Errorf("node not found: %s", node)
 	}
 
 	header := requestHeader{

--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -188,6 +189,23 @@ func (c *RPCClient) Close() error {
 // ForceLeave is used to ask the agent to issue a leave command for
 // a given node
 func (c *RPCClient) ForceLeave(node string) error {
+	mem, err := c.Members()
+	if err != nil {
+		return err
+	}
+
+	found := false
+	for _, m := range mem {
+		if m.Name == node {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return errors.New(fmt.Sprintf("couldn't find node %s", node))
+	}
+
 	header := requestHeader{
 		Command: forceLeaveCommand,
 		Seq:     c.getSeq(),

--- a/cmd/serf/command/force_leave_test.go
+++ b/cmd/serf/command/force_leave_test.go
@@ -121,4 +121,8 @@ WAIT:
 	if code != 1 {
 		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
 	}
+
+	if !strings.Contains(ui.ErrorWriter.String(), "node not found: invalidNode") {
+		t.Fatalf("bad: %#v", ui.ErrorWriter.String())
+	}
 }

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -768,6 +768,19 @@ func (s *Serf) RemoveFailedNode(node string) error {
 		return nil
 	}
 
+	found := false
+	mem := s.Members()
+	for _, m := range mem {
+		if m.Name == node {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return fmt.Errorf("node not found: %s", node)
+	}
+
 	// Broadcast the remove
 	notifyCh := make(chan struct{})
 	if err := s.broadcast(messageLeaveType, &msg, notifyCh); err != nil {

--- a/serf/serf_test.go
+++ b/serf/serf_test.go
@@ -214,7 +214,7 @@ func TestSerf_eventsLeave(t *testing.T) {
 		[]EventType{EventMemberJoin, EventMemberLeave})
 }
 
-func TestSerf_RemoveFailed_eventsLeave(t *testing.T) {
+func TestSerf_RemoveFailedNode_eventsLeave(t *testing.T) {
 	// Create the s1 config with an event channel so we can listen
 	eventCh := make(chan Event, 4)
 	s1Config := testConfig()

--- a/serf/serf_test.go
+++ b/serf/serf_test.go
@@ -851,6 +851,36 @@ func TestSerfRemoveFailedNode_ourself(t *testing.T) {
 	}
 }
 
+func TestSerfRemoveFailedNode_invaidNode(t *testing.T) {
+	s1Config := testConfig()
+	s2Config := testConfig()
+
+	s1, err := Create(s1Config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	s2, err := Create(s2Config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	defer s1.Shutdown()
+	defer s2.Shutdown()
+
+	_, err = s1.Join([]string{s2Config.MemberlistConfig.BindAddr}, false)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	testutil.Yield()
+
+	// Now remove the failed node
+	if err := s1.RemoveFailedNode("invalidNode"); err == nil {
+		t.Fatalf("bad: expected a failure")
+	}
+}
+
 func TestSerfState(t *testing.T) {
 	s1, err := Create(testConfig())
 	if err != nil {

--- a/website/source/docs/commands/force-leave.html.markdown
+++ b/website/source/docs/commands/force-leave.html.markdown
@@ -21,6 +21,9 @@ Serf will reap "failed" nodes and stop trying to reconnect. The `force-leave`
 command can be used to transition the "failed" nodes to "left" nodes more
 quickly.
 
+This command will return 0 if the member leaves successfully and there are no errors.
+If for example the node cannot be found, it returns 1.
+
 ## Usage
 
 Usage: `serf force-leave [options] node`


### PR DESCRIPTION
This PR fixes #500 and https://github.com/hashicorp/consul/issues/3757. I added a test and mentioned the return code in the docs since it changes the CLI return codes.

I notices a couple of things during implementing and testing the changes: 

1) when there are no members, serf doesn't do anything. But after this change I would expect that it says that there are no nodes and that force leaving is not possible.
2) since consul uses `RemoveFailedNode`, consul's CLI is changing as well. Before it returned 0, now it returns 1 if you try to remove a node that doesn't exist.
Before: 
```
MacBook-Pro% consul force-leave abc; echo $?;
0
```
After:
```
MacBook-Pro% consul force-leave abc; echo $?;
Error force leaving: Unexpected response code: 500 (node not found: abc)
1
```

3) I noticed that a node cannot `force-leave` itself