### PR TITLE
Ensure node leave intents are handled correctly

### DIFF
--- a/cmd/serf/command/agent/command_test.go
+++ b/cmd/serf/command/agent/command_test.go
@@ -52,7 +52,7 @@ func TestCommandRun(t *testing.T) {
 		if code != 0 {
 			t.Fatalf("bad code: %d", code)
 		}
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(2 * time.Second):
 		t.Fatalf("timeout")
 	}
 }

--- a/serf/config.go
+++ b/serf/config.go
@@ -262,7 +262,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		NodeName:                     hostname,
 		BroadcastTimeout:             5 * time.Second,
-		LeavePropagateDelay: 		  2 * time.Second,
+		LeavePropagateDelay: 		  1 * time.Second,
 		EventBuffer:                  512,
 		QueryBuffer:                  512,
 		LogOutput:                    os.Stderr,

--- a/serf/config.go
+++ b/serf/config.go
@@ -262,7 +262,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		NodeName:                     hostname,
 		BroadcastTimeout:             5 * time.Second,
-		LeavePropagateDelay: 		  1 * time.Second,
+		LeavePropagateDelay:          1 * time.Second,
 		EventBuffer:                  512,
 		QueryBuffer:                  512,
 		LogOutput:                    os.Stderr,

--- a/serf/config.go
+++ b/serf/config.go
@@ -55,6 +55,13 @@ type Config struct {
 	// set, a timeout of 5 seconds will be set.
 	BroadcastTimeout time.Duration
 
+	// LeavePropagateDelay is for our leave (node dead) message to propagate
+	// through the cluster. In particular, we want to stay up long enough to
+	// service any probes from other nodes before they learn about us
+	// leaving and stop probing. Otherwise, we risk getting node failures as
+	// we leave.
+	LeavePropagateDelay time.Duration
+
 	// The settings below relate to Serf's event coalescence feature. Serf
 	// is able to coalesce multiple events into single events in order to
 	// reduce the amount of noise that is sent along the EventCh. For example
@@ -255,6 +262,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		NodeName:                     hostname,
 		BroadcastTimeout:             5 * time.Second,
+		LeavePropagateDelay: 		  2 * time.Second,
 		EventBuffer:                  512,
 		QueryBuffer:                  512,
 		LogOutput:                    os.Stderr,

--- a/serf/delegate_test.go
+++ b/serf/delegate_test.go
@@ -116,12 +116,13 @@ func TestDelegate_LocalState(t *testing.T) {
 	}
 
 	// Verify the status
-	if len(pp.StatusLTimes) != 2 {
+	// Leave waits until propagation so this should only have one member
+	if len(pp.StatusLTimes) != 1 {
 		t.Fatalf("missing ltimes")
 	}
 
-	if len(pp.LeftMembers) != 1 {
-		t.Fatalf("missing left members")
+	if len(pp.LeftMembers) != 0 {
+		t.Fatalf("should have no left members")
 	}
 
 	if pp.EventLTime != s1.eventClock.Time() {
@@ -191,7 +192,7 @@ func TestDelegate_MergeRemoteState(t *testing.T) {
 	}
 
 	// Verify pending leave for foo
-	if leave, ok := recentIntent(s1.recentIntents, "foo", messageLeaveType); !ok || leave != 15 {
+	if leave, ok := recentIntent(s1.recentIntents, "foo", messageLeaveType); !ok || leave != 16 {
 		t.Fatalf("bad recent leave")
 	}
 

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -691,6 +691,13 @@ func (s *Serf) Leave() error {
 		return err
 	}
 
+	// Wait for the leave to propagate through the cluster. The broadcast
+	// timeout is how long we wait for the message to go out from our own
+	// queue, but this wait is for that message to propagate through the
+	// cluster. In particular, we want to stay up long enough to service
+	// any probes from other nodes before they learn about us leaving.
+	time.Sleep(s.config.LeavePropagateDelay)
+
 	// Transition to Left only if we not already shutdown
 	s.stateLock.Lock()
 	if s.state != SerfShutdown {

--- a/serf/serf_test.go
+++ b/serf/serf_test.go
@@ -1345,9 +1345,9 @@ func TestSerf_Leave_SnapshotRecovery(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 	time.Sleep(s2Config.MemberlistConfig.ProbeInterval * 5)
-
-	// Verify that s2 is "left"
-	testMember(t, s1.Members(), s2Config.NodeName, StatusLeft)
+	// Verify that s2 is not in the memberlist
+	// The join intent is ignored because the leave sleeps long enough for the leave intent to broadcast
+	testMember(t, s1.Members(), s2Config.NodeName, StatusNone)
 
 	// Restart s2 from the snapshot now!
 	s2Config.EventCh = nil
@@ -1361,7 +1361,7 @@ func TestSerf_Leave_SnapshotRecovery(t *testing.T) {
 	testutil.Yield()
 
 	// Verify that s2 is didn't join
-	testMember(t, s1.Members(), s2Config.NodeName, StatusLeft)
+	testMember(t, s1.Members(), s2Config.NodeName, StatusNone)
 	if s2.NumNodes() != 1 {
 		t.Fatalf("bad members: %#v", s2.Members())
 	}

--- a/serf/serf_test.go
+++ b/serf/serf_test.go
@@ -174,6 +174,9 @@ func TestSerf_eventsLeave(t *testing.T) {
 	eventCh := make(chan Event, 4)
 	s1Config := testConfig()
 	s1Config.EventCh = eventCh
+	// Make the reap interval longer in this test
+	// so that the leave does not also cause a reap
+	s1Config.ReapInterval = 30 * time.Second
 
 	s2Config := testConfig()
 


### PR DESCRIPTION
This PR adds a configurable leave timeout to allow leave intent broadcasts to propagate before returning from the Leave method. 

It also fixes an edge case in  anti entropy sync where a left member in the push/pull message's payload would not get processed because its lamport time was incorrectly set.

Brings in work done in an experimental branch by @slackpad 