### PR TITLE
build: Update to Go 1.10.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.8
+  - 1.10.x
 
 branches:
   only:


### PR DESCRIPTION
This commit updates Travis CI to use Go 1.10.x - i.e. the latest version at a given point in the 1.10 series.