### PR TITLE
Add tests to verify snapshotter doesn't block.

### DIFF
--- a/serf/snapshot_test.go
+++ b/serf/snapshot_test.go
@@ -432,7 +432,7 @@ func TestSnapshotter_slowDiskNotBlockingEventCh(t *testing.T) {
 				},
 			}
 			if i%10 == 0 {
-				// send a leave for every 10 joins
+				// 1/10 events is a leave
 				e.Type = EventMemberLeave
 			}
 			inCh <- e
@@ -513,7 +513,7 @@ func TestSnapshotter_blockedUpstreamNotBlockingMemberlist(t *testing.T) {
 			},
 		}
 		if i%10 == 0 {
-			// send a leave for every 10 joins
+			// 1/10 events is a leave
 			e.Type = EventMemberLeave
 		}
 		select {


### PR DESCRIPTION
We specifically test that neither disk IO nor upstream slowness causes the input to input channel to block. If it does memberlist stops being able to process messages and causes cluster instability.

This new test is kinda janky and is certainly timing dependent. That said I tried to ensure it will pass reliably while actually validating an important property.

Since it's not obvious, the exact same test code run against the previous version on Snapshotter where disk IO was syncronous fails this same test very reliably (100/100) while at least on my laptop we now pass it 100/100 attempts and with a lot of overhead on the timing (~115ms out of the 500ms we allow).

See results here: https://gist.github.com/banks/ed70f83322165b731b1d333728c0ad23

There are some subtleties as commented - if we send a full speed then the property of never blocking the input chan actually causes us to drop messages.