### PR TITLE
Make event compression optional

### DIFF
--- a/cmd/serf/command/agent/agent.go
+++ b/cmd/serf/command/agent/agent.go
@@ -54,6 +54,7 @@ func Create(agentConf *Config, conf *serf.Config, logOutput io.Writer) (*Agent, 
 
 	// Setup the underlying loggers
 	conf.MemberlistConfig.LogOutput = logOutput
+	conf.MemberlistConfig.EnableCompression = agentConf.EnableCompression
 	conf.LogOutput = logOutput
 
 	// Create a channel to listen for events from Serf

--- a/cmd/serf/command/agent/command.go
+++ b/cmd/serf/command/agent/command.go
@@ -55,6 +55,8 @@ func (c *Command) readConfig() *Config {
 	var tags []string
 	var retryInterval string
 	var broadcastTimeout string
+	var disableCompression bool
+
 	cmdFlags := flag.NewFlagSet("agent", flag.ContinueOnError)
 	cmdFlags.Usage = func() { c.Ui.Output(c.Help()) }
 	cmdFlags.StringVar(&cmdConfig.BindAddr, "bind", "", "address to bind listeners to")
@@ -92,10 +94,20 @@ func (c *Command) readConfig() *Config {
 	cmdFlags.StringVar(&retryInterval, "retry-interval", "", "retry join interval")
 	cmdFlags.BoolVar(&cmdConfig.RejoinAfterLeave, "rejoin", false,
 		"enable re-joining after a previous leave")
+
+	cmdFlags.BoolVar(
+		&disableCompression,
+		"disable-compression",
+		false,
+		"disable message compression for broadcasting events",
+	)
+
 	cmdFlags.StringVar(&broadcastTimeout, "broadcast-timeout", "", "timeout for broadcast messages")
 	if err := cmdFlags.Parse(c.args); err != nil {
 		return nil
 	}
+
+	cmdConfig.EnableCompression = !disableCompression
 
 	// Parse any command line tag values
 	tagValues, err := UnmarshalTags(tags)
@@ -448,13 +460,14 @@ func (c *Command) startAgent(config *Config, agent *Agent,
 		c.Ui.Info(fmt.Sprintf("Advertise addr: '%s'", advertiseAddr))
 	}
 
-	c.Ui.Info(fmt.Sprintf("      RPC addr: '%s'", config.RPCAddr))
-	c.Ui.Info(fmt.Sprintf("     Encrypted: %#v", agent.serf.EncryptionEnabled()))
-	c.Ui.Info(fmt.Sprintf("      Snapshot: %v", config.SnapshotPath != ""))
-	c.Ui.Info(fmt.Sprintf("       Profile: %s", config.Profile))
+	c.Ui.Info(fmt.Sprintf("                   RPC addr: '%s'", config.RPCAddr))
+	c.Ui.Info(fmt.Sprintf("                  Encrypted: %#v", agent.serf.EncryptionEnabled()))
+	c.Ui.Info(fmt.Sprintf("                   Snapshot: %v", config.SnapshotPath != ""))
+	c.Ui.Info(fmt.Sprintf("                    Profile: %s", config.Profile))
+	c.Ui.Info(fmt.Sprintf("Message Compression Enabled: %v", config.EnableCompression))
 
 	if config.Discover != "" {
-		c.Ui.Info(fmt.Sprintf("  mDNS cluster: %s", config.Discover))
+		c.Ui.Info(fmt.Sprintf("               mDNS cluster: %s", config.Discover))
 	}
 	return ipc
 }
@@ -752,6 +765,7 @@ Options:
   -retry-interval=30s      Sets the interval on which a node will attempt to retry joining
                            nodes provided by -retry-join. Defaults to 30s.
   -retry-max=0             Limits the number of retry events. Defaults to 0 for unlimited.
+  -disable-compression     Disable message compression for broadcasting events. Enabled by default.
   -role=foo                The role of this node, if any. This can be used
                            by event scripts to differentiate different types
                            of nodes that may be part of the same cluster.

--- a/cmd/serf/command/agent/config.go
+++ b/cmd/serf/command/agent/config.go
@@ -205,6 +205,10 @@ type Config struct {
 	// only has an affect if the snapshot file is enabled.
 	RejoinAfterLeave bool `mapstructure:"rejoin_after_leave"`
 
+	// EnableCompression specifies whether message compression is enabled
+	// by `github.com/hashicorp/memberlist` when broadcasting events.
+	EnableCompression bool `mapstructure:"enable_compression"`
+
 	// StatsiteAddr is the address of a statsite instance. If provided,
 	// metrics will be streamed to that instance.
 	StatsiteAddr string `mapstructure:"statsite_addr"`
@@ -462,6 +466,7 @@ func MergeConfig(a, b *Config) *Config {
 	if b.BroadcastTimeout != 0 {
 		result.BroadcastTimeout = b.BroadcastTimeout
 	}
+	result.EnableCompression = b.EnableCompression
 
 	// Copy the event handlers
 	result.EventHandlers = make([]string, 0, len(a.EventHandlers)+len(b.EventHandlers))

--- a/cmd/serf/command/agent/config_test.go
+++ b/cmd/serf/command/agent/config_test.go
@@ -412,6 +412,7 @@ func TestMergeConfig(t *testing.T) {
 		QueryResponseSizeLimit: 123,
 		QuerySizeLimit:         456,
 		BroadcastTimeout:       20 * time.Second,
+		EnableCompression:      true,
 	}
 
 	c := MergeConfig(a, b)
@@ -515,6 +516,10 @@ func TestMergeConfig(t *testing.T) {
 	}
 
 	if c.BroadcastTimeout != 20*time.Second {
+		t.Fatalf("bad: %#v", c)
+	}
+
+	if !c.EnableCompression {
 		t.Fatalf("bad: %#v", c)
 	}
 }

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -141,6 +141,8 @@ The options below are all specified on the command-line.
 * `-retry-max` - Provides a limit on how many attempts to join the cluster
   can be made by `-retry-join`. If 0, there is no limit, and the agent will
   retry forever. Defaults to 0.
+  
+* `-disable-compression` - Disable message compression for broadcasting events. Enabled by default. **Useful for debugging message payloads**.
 
 * `-role` - **Deprecated** The role of this node, if any. By default this is blank or empty.
   The role can be used by events in order to differentiate members of a


### PR DESCRIPTION
Adds CLI argument `enable-compression=<bool>` to `serf agent`.

This is to make debugging much easier w/o having LZW compression of messages by `memberlist`.

Signed-off-by: Anton Antonov <anton.synd.antonov@gmail.com>

@banks 