### PR TITLE
 Make `UserEventSizeLimit` configurable and fix `UserEventSizeLimit` check

### DIFF
--- a/cmd/serf/command/agent/command.go
+++ b/cmd/serf/command/agent/command.go
@@ -451,8 +451,8 @@ func (c *Command) startAgent(config *Config, agent *Agent,
 	ipc := NewAgentIPC(agent, config.RPCAuthKey, rpcListener, logOutput, logWriter)
 
 	c.Ui.Output("Serf agent running!")
-	c.Ui.Info(fmt.Sprintf("     Node name: '%s'", config.NodeName))
-	c.Ui.Info(fmt.Sprintf("     Bind addr: '%s'", bindAddr.String()))
+	c.Ui.Info(fmt.Sprintf("                  Node name: '%s'", config.NodeName))
+	c.Ui.Info(fmt.Sprintf("                  Bind addr: '%s'", bindAddr.String()))
 
 	if config.AdvertiseAddr != "" {
 		advertiseIP, advertisePort, _ := config.AddrParts(config.AdvertiseAddr)

--- a/cmd/serf/command/agent/command.go
+++ b/cmd/serf/command/agent/command.go
@@ -327,6 +327,7 @@ func (c *Command) setupAgent(config *Config, logOutput io.Writer) *Agent {
 	serfConfig.QuiescentPeriod = time.Second
 	serfConfig.QueryResponseSizeLimit = config.QueryResponseSizeLimit
 	serfConfig.QuerySizeLimit = config.QuerySizeLimit
+	serfConfig.UserEventSizeLimit = config.UserEventSizeLimit
 	serfConfig.UserCoalescePeriod = 3 * time.Second
 	serfConfig.UserQuiescentPeriod = time.Second
 	if config.ReconnectInterval != 0 {

--- a/cmd/serf/command/agent/config.go
+++ b/cmd/serf/command/agent/config.go
@@ -35,6 +35,7 @@ func DefaultConfig() *Config {
 		SyslogFacility:         "LOCAL0",
 		QueryResponseSizeLimit: 1024,
 		QuerySizeLimit:         1024,
+		UserEventSizeLimit:     512,
 		BroadcastTimeout:       5 * time.Second,
 	}
 }
@@ -113,6 +114,10 @@ type Config struct {
 	// configuration.
 	QueryResponseSizeLimit int `mapstructure:"query_response_size_limit"`
 	QuerySizeLimit         int `mapstructure:"query_size_limit"`
+
+	// UserEventSizeLimit is maximum byte size limit of user event `name` + `payload` in bytes.
+	// It's optimal to be relatively small, since it's going to be gossiped through the cluster.
+	UserEventSizeLimit int `mapstructure:"user_event_size_limit"`
 
 	// StartJoin is a list of addresses to attempt to join when the
 	// agent starts. If Serf is unable to communicate with any of these
@@ -462,6 +467,9 @@ func MergeConfig(a, b *Config) *Config {
 	}
 	if b.QuerySizeLimit != 0 {
 		result.QuerySizeLimit = b.QuerySizeLimit
+	}
+	if b.UserEventSizeLimit != 0 {
+		result.UserEventSizeLimit = b.UserEventSizeLimit
 	}
 	if b.BroadcastTimeout != 0 {
 		result.BroadcastTimeout = b.BroadcastTimeout

--- a/serf/config.go
+++ b/serf/config.go
@@ -242,6 +242,10 @@ type Config struct {
 	// Merge can be optionally provided to intercept a cluster merge
 	// and conditionally abort the merge.
 	Merge MergeDelegate
+
+	// UserEventSizeLimit is maximum byte size limit of user event `name` + `payload` in bytes.
+	// It's optimal to be relatively small, since it's going to be gossiped through the cluster.
+	UserEventSizeLimit int
 }
 
 // Init allocates the subdata structures
@@ -282,5 +286,6 @@ func DefaultConfig() *Config {
 		QuerySizeLimit:               1024,
 		EnableNameConflictResolution: true,
 		DisableCoordinates:           false,
+		UserEventSizeLimit:           512,
 	}
 }

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -223,8 +223,7 @@ type queries struct {
 }
 
 const (
-	UserEventSizeLimit = 512        // Maximum byte size for event name and payload
-	snapshotSizeLimit  = 128 * 1024 // Maximum 128 KB snapshot
+	snapshotSizeLimit = 128 * 1024 // Maximum 128 KB snapshot
 )
 
 // Create creates a new Serf instance, starting all the background tasks
@@ -437,14 +436,13 @@ func (s *Serf) KeyManager() *KeyManager {
 }
 
 // UserEvent is used to broadcast a custom user event with a given
-// name and payload. The events must be fairly small, and if the
-// size limit is exceeded and error will be returned. If coalesce is enabled,
-// nodes are allowed to coalesce this event. Coalescing is only available
-// starting in v0.2
+// name and payload. If the configured size limit is exceeded and error will be returned.
+// If coalesce is enabled, nodes are allowed to coalesce this event.
+// Coalescing is only available starting in v0.2
 func (s *Serf) UserEvent(name string, payload []byte, coalesce bool) error {
 	// Check the size limit
-	if len(name)+len(payload) > UserEventSizeLimit {
-		return fmt.Errorf("user event exceeds limit of %d bytes", UserEventSizeLimit)
+	if len(name)+len(payload) > s.config.UserEventSizeLimit {
+		return fmt.Errorf("user event exceeds limit of %d bytes", s.config.UserEventSizeLimit)
 	}
 
 	// Create a message

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -224,6 +224,7 @@ type queries struct {
 
 const (
 	snapshotSizeLimit = 128 * 1024 // Maximum 128 KB snapshot
+	UserEventSizeLimit = 9 * 1024  // Maximum 9KB for event name and payload
 )
 
 // Create creates a new Serf instance, starting all the background tasks
@@ -239,6 +240,10 @@ func Create(conf *Config) (*Serf, error) {
 	} else if conf.ProtocolVersion > ProtocolVersionMax {
 		return nil, fmt.Errorf("Protocol version '%d' too high. Must be in range: [%d, %d]",
 			conf.ProtocolVersion, ProtocolVersionMin, ProtocolVersionMax)
+	}
+
+	if conf.UserEventSizeLimit > UserEventSizeLimit {
+		return nil, fmt.Errorf("user event size limit exceeds limit of %d bytes", UserEventSizeLimit)
 	}
 
 	logger := conf.Logger
@@ -440,9 +445,21 @@ func (s *Serf) KeyManager() *KeyManager {
 // If coalesce is enabled, nodes are allowed to coalesce this event.
 // Coalescing is only available starting in v0.2
 func (s *Serf) UserEvent(name string, payload []byte, coalesce bool) error {
-	// Check the size limit
-	if len(name)+len(payload) > s.config.UserEventSizeLimit {
-		return fmt.Errorf("user event exceeds limit of %d bytes", s.config.UserEventSizeLimit)
+	payloadSizeBeforeEncoding := len(name)+len(payload)
+
+	// Check size before encoding to prevent needless encoding and return early if it's over the specified limit.
+	if payloadSizeBeforeEncoding > s.config.UserEventSizeLimit {
+		return fmt.Errorf(
+			"user event exceeds configured limit of %d bytes before encoding",
+			s.config.UserEventSizeLimit,
+		)
+	}
+
+	if payloadSizeBeforeEncoding > UserEventSizeLimit {
+		return fmt.Errorf(
+			"user event exceeds sane limit of %d bytes before encoding",
+			UserEventSizeLimit,
+		)
 	}
 
 	// Create a message
@@ -452,16 +469,34 @@ func (s *Serf) UserEvent(name string, payload []byte, coalesce bool) error {
 		Payload: payload,
 		CC:      coalesce,
 	}
-	s.eventClock.Increment()
-
-	// Process update locally
-	s.handleUserEvent(&msg)
 
 	// Start broadcasting the event
 	raw, err := encodeMessage(messageUserEventType, &msg)
 	if err != nil {
 		return err
 	}
+
+	// Check the size after encoding to be sure again that
+	// we're not attempting to send over the specified size limit.
+	if len(raw) > s.config.UserEventSizeLimit {
+		return fmt.Errorf(
+			"encoded user event exceeds configured limit of %d bytes after encoding",
+			s.config.UserEventSizeLimit,
+		)
+	}
+
+	if len(raw) > UserEventSizeLimit {
+		return fmt.Errorf(
+			"encoded user event exceeds sane limit of %d bytes before encoding",
+			UserEventSizeLimit,
+		)
+	}
+
+	s.eventClock.Increment()
+
+	// Process update locally
+	s.handleUserEvent(&msg)
+
 	s.eventBroadcasts.QueueBroadcast(&broadcast{
 		msg: raw,
 	})

--- a/serf/serf_test.go
+++ b/serf/serf_test.go
@@ -322,7 +322,7 @@ func TestSerf_eventsUser_sizeLimit(t *testing.T) {
 	defer s1.Shutdown()
 
 	name := "this is too large an event"
-	payload := make([]byte, UserEventSizeLimit)
+	payload := make([]byte, s1Config.UserEventSizeLimit)
 	err = s1.UserEvent(name, payload, false)
 	if err == nil {
 		t.Fatalf("expect error")

--- a/website/source/docs/agent/basics.html.markdown
+++ b/website/source/docs/agent/basics.html.markdown
@@ -22,13 +22,15 @@ running `serf agent`, you should see output similar to that below:
 ```
 $ serf agent
 ==> Starting Serf agent...
+==> Starting Serf agent RPC...
 ==> Serf agent running!
-    Node name: 'mitchellh.local'
-    Bind addr: '0.0.0.0:7946'
-     RPC addr: '127.0.0.1:7373'
-    Encrypted: false
-     Snapshot: false
-      Profile: lan
+                    Node name: 'mitchellh.local'
+                    Bind addr: '0.0.0.0:7946'
+                     RPC addr: '127.0.0.1:7373'
+                    Encrypted: false
+                     Snapshot: false
+                      Profile: lan
+  Message Compression Enabled: true
 
 ==> Log data will now stream in as it occurs:
 

--- a/website/source/docs/internals/gossip.html.markdown
+++ b/website/source/docs/internals/gossip.html.markdown
@@ -85,7 +85,7 @@ The changes from SWIM are noted here:
 SWIM makes the assumption that the local node is healthy in the sense
 that soft real-time processing of packets is possible. However, in cases
 where the local node is experiencing CPU or network exhaustion this assumption
-can be violated. The result is that the node health can occassionally flap,
+can be violated. The result is that the node health can occasionally flap,
 resulting in false monitoring alarms, adding noise to telemetry, and simply
 causing the overall cluster to waste CPU and network resources diagnosing a
 failure that may not truly exist.

--- a/website/source/docs/internals/gossip.html.markdown
+++ b/website/source/docs/internals/gossip.html.markdown
@@ -135,5 +135,10 @@ it can be ordered properly in case a leave comes out of order.
 
 For custom events and queries, Serf sends either a _user event_,
 or _user query_ message. This message contains a Lamport time, event name, and event payload.
-Because user events are sent along the gossip layer, which uses UDP, the payload and entire message framing
-must fit within a single UDP packet.
+Because user events are sent along the gossip layer, which uses UDP, 
+the payload and entire message framing must fit within a single UDP packet.
+
+`UserEventSizeLimit` can be configured, but a hard limit of `9KB` is applied.
+It's up to the user to make sure that the "user event"'s network transmission "path" fits their MTU and/or other packet constraints.
+ 
+ 


### PR DESCRIPTION
Different usages, needs different `UserEventSizeLimit`.
It's understood that having a big event size is going to make the
broadcast and replication across the cluster slow depending on the size.

Other serf broadcast timeout and replication timeout settings must be configured accordingly!


Also fix the check:

* Make it more reliable in terms of payload size since only the encoded message is checked.
* Make it consistent with `QuerySizeLimit`.

@banks Another one. Although I require some HashiCorp knowledge why it wasn't configurable before. My idea is to piggyback on the `UserEvent` to send application events that may be greater than `512` bytes, but in any case they must be configurable. `QuerySizeLimit` has been taken into account as another example how it is risky, yet configurable.

P.S https://media.giphy.com/media/GV3aYiEP8qbao/giphy.gif
