### PR TITLE
[WIP] Remove deprecated usage of memberlist.SendTo

### DIFF
--- a/serf/delegate.go
+++ b/serf/delegate.go
@@ -102,7 +102,9 @@ func (d *delegate) NotifyMsg(buf []byte) {
 		raw := make([]byte, reader.Len())
 		reader.Read(raw)
 		d.serf.logger.Printf("[DEBUG] serf: Relaying response to addr: %s", header.DestAddr.String())
-		if err := d.serf.memberlist.SendTo(&header.DestAddr, raw); err != nil {
+
+		node := &memberlist.Node{Addr: header.DestAddr.IP, Port: uint16(header.DestAddr.Port)}
+		if err := d.serf.memberlist.SendBestEffort(node, raw); err != nil {
 			d.serf.logger.Printf("[ERR] serf: Error forwarding message to %s: %s", header.DestAddr.String(), err)
 			break
 		}

--- a/serf/event.go
+++ b/serf/event.go
@@ -2,6 +2,7 @@ package serf
 
 import (
 	"fmt"
+	"github.com/hashicorp/memberlist"
 	"net"
 	"sync"
 	"time"
@@ -158,11 +159,12 @@ func (q *Query) Respond(buf []byte) error {
 	}
 
 	// Send the response directly to the originator
-	addr := net.UDPAddr{IP: q.addr, Port: int(q.port)}
-	if err := q.serf.memberlist.SendTo(&addr, raw); err != nil {
+	node := &memberlist.Node{Addr: q.addr, Port: q.port}
+	if err := q.serf.memberlist.SendBestEffort(node, raw); err != nil {
 		return err
 	}
 
+	addr := net.UDPAddr{IP: q.addr, Port: int(q.port)}
 	// Relay the response through up to relayFactor other nodes
 	if err := q.serf.relayResponse(q.relayFactor, addr, &resp); err != nil {
 		return err

--- a/serf/query.go
+++ b/serf/query.go
@@ -3,6 +3,7 @@ package serf
 import (
 	"errors"
 	"fmt"
+	"github.com/hashicorp/memberlist"
 	"math"
 	"math/rand"
 	"net"
@@ -271,8 +272,8 @@ func (s *Serf) relayResponse(relayFactor uint8, addr net.UDPAddr, resp *messageQ
 		return m.Status != StatusAlive || m.ProtocolMax < 5 || m.Name == localName
 	})
 	for _, m := range relayMembers {
-		relayAddr := net.UDPAddr{IP: m.Addr, Port: int(m.Port)}
-		if err := s.memberlist.SendTo(&relayAddr, raw); err != nil {
+		node := &memberlist.Node{Addr: m.Addr, Port: m.Port}
+		if err := s.memberlist.SendBestEffort(node, raw); err != nil {
 			return fmt.Errorf("failed to send relay response: %v", err)
 		}
 	}

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -1248,10 +1248,12 @@ func (s *Serf) handleQuery(query *messageQuery) bool {
 		if err != nil {
 			s.logger.Printf("[ERR] serf: failed to format ack: %v", err)
 		} else {
-			addr := net.UDPAddr{IP: query.Addr, Port: int(query.Port)}
-			if err := s.memberlist.SendTo(&addr, raw); err != nil {
+			node := &memberlist.Node{Addr: query.Addr, Port: query.Port}
+			if err := s.memberlist.SendBestEffort(node, raw); err != nil {
 				s.logger.Printf("[ERR] serf: failed to send ack: %v", err)
 			}
+
+			addr := net.UDPAddr{IP: query.Addr, Port: int(query.Port)}
 			if err := s.relayResponse(query.RelayFactor, addr, &ack); err != nil {
 				s.logger.Printf("[ERR] serf: failed to relay ack: %v", err)
 			}


### PR DESCRIPTION
Addresses

```
// SendTo is deprecated in favor of SendBestEffort, which requires a node to target.
```

Ref: https://github.com/hashicorp/memberlist/blob/master/memberlist.go#L476

This is a small deprecation warning fix without introducing significant overhead of the existing structs.
There were really no attempts to change the current structs since I don't think this is the right time to do so.

A significant downside, though that it breaks the promise of reliable encapsulation.

I had to know what the `memberlist.SendBestEffort` does inside `node.Address` to know that I only need `Addr` and `Port`. Which on the other hand makes you think why is `node` part of the signature of `SendBestEffort` (https://github.com/hashicorp/memberlist/blob/master/memberlist.go#L500) and whether being consistent with `SendReliable` (https://github.com/hashicorp/memberlist/blob/master/memberlist.go#L514) which also uses a `node` is a good enough reason.

Most importantly this is a step towards enabling greater changes in the underlying usage of memberlist which in many places is "hard-coded" to be just UDP.

TODO: Fix broken tests


Signed-off-by: Anton Antonov <anton.synd.antonov@gmail.com>