### PR TITLE
Truncate key list response

### DIFF
--- a/serf/internal_query.go
+++ b/serf/internal_query.go
@@ -31,7 +31,7 @@ const (
 	listKeysQuery = "list-keys"
 
 	// maxListKeyFactor is used to compute the max number of keys in a list key
-	// response. eg 1024/25 = 40. a message of with max size of 1024 bytes cannot
+	// response. eg 1024/25 = 40. a message with max size of 1024 bytes cannot
 	// contain more than 40 keys. There is a test
 	// (TestSerfQueries_estimateMaxKeysInListKeyResponse) which does the
 	// computation and in case of changes, the value can be adjusted.

--- a/serf/internal_query.go
+++ b/serf/internal_query.go
@@ -30,12 +30,12 @@ const (
 	// listKeysQuery is used to list all known keys in the cluster
 	listKeysQuery = "list-keys"
 
-	// maxListKeyFactor is used to compute the max number of keys in a list key
+	// minEncodedKeyLength is used to compute the max number of keys in a list key
 	// response. eg 1024/25 = 40. a message with max size of 1024 bytes cannot
 	// contain more than 40 keys. There is a test
 	// (TestSerfQueries_estimateMaxKeysInListKeyResponse) which does the
 	// computation and in case of changes, the value can be adjusted.
-	maxListKeyFactor = 25
+	minEncodedKeyLength = 25
 )
 
 // internalQueryName is used to generate a query name for an internal query
@@ -158,7 +158,7 @@ func (s *serfQueries) handleConflict(q *Query) {
 }
 
 func (s *serfQueries) keyListResponseWithCorrectSize(q *Query, resp *nodeKeyResponse) ([]byte, messageQueryResponse, error) {
-	maxListKeys := q.serf.config.QueryResponseSizeLimit / maxListKeyFactor
+	maxListKeys := q.serf.config.QueryResponseSizeLimit / minEncodedKeyLength
 	actual := len(resp.Keys)
 	for i := maxListKeys; i >= 0; i-- {
 		buf, err := encodeMessage(messageKeyResponseType, resp)

--- a/serf/internal_query_test.go
+++ b/serf/internal_query_test.go
@@ -131,7 +131,7 @@ func TestSerfQueries_keyListResponseWithCorrectSize(t *testing.T) {
 		{expected: 0, hasMsg: false, resp: nodeKeyResponse{}},
 		{expected: 1, hasMsg: false, resp: nodeKeyResponse{Keys: []string{"LeJcrRIZsZ9tPYJZW7Xllg=="}}},
 		// has 50 keys which makes the response bigger than 1024 bytes.
-		{expected: 37, hasMsg: true, resp: nodeKeyResponse{Keys: []string{
+		{expected: 36, hasMsg: true, resp: nodeKeyResponse{Keys: []string{
 			"LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==",
 			"LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==",
 			"LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==",

--- a/serf/internal_query_test.go
+++ b/serf/internal_query_test.go
@@ -89,7 +89,7 @@ func TestSerfQueries_Conflict_SameName(t *testing.T) {
 }
 
 func TestSerfQueries_keyListResponseWithCorrectSize(t *testing.T) {
-	s := serfQueries{}
+	s := serfQueries{logger: log.New(os.Stderr, "", log.LstdFlags)}
 	q := Query{id: 1136243741, serf: &Serf{config: &Config{NodeName: "foo.dc1", QueryResponseSizeLimit: 160}}}
 	cases := []struct {
 		resp     nodeKeyResponse

--- a/serf/keymanager.go
+++ b/serf/keymanager.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 )
 
-const MagicTruncationNumber = 50
-
 // KeyManager encapsulates all functionality within Serf for handling
 // encryption keyring changes across a cluster.
 type KeyManager struct {
@@ -70,8 +68,8 @@ func (k *KeyManager) streamKeyResp(resp *KeyResponse, ch <-chan NodeResponse) {
 			resp.NumErr++
 		}
 
-		if len(r.Payload)+MagicTruncationNumber > k.serf.config.QueryResponseSizeLimit {
-			k.serf.logger.Println("[WARN] serf: the response is close to the QueryResponseSizeLimit and might have been truncated")
+		if nodeResponse.Result && len(nodeResponse.Message) > 0 {
+			k.serf.logger.Println("[WARN] serf:", nodeResponse.Message)
 		}
 
 		// Currently only used for key list queries, this adds keys to a counter

--- a/serf/keymanager.go
+++ b/serf/keymanager.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 )
 
+const MagicTruncationNumber = 50
+
 // KeyManager encapsulates all functionality within Serf for handling
 // encryption keyring changes across a cluster.
 type KeyManager struct {
@@ -66,6 +68,10 @@ func (k *KeyManager) streamKeyResp(resp *KeyResponse, ch <-chan NodeResponse) {
 		if !nodeResponse.Result {
 			resp.Messages[r.From] = nodeResponse.Message
 			resp.NumErr++
+		}
+
+		if len(r.Payload)+MagicTruncationNumber > k.serf.config.QueryResponseSizeLimit {
+			k.serf.logger.Println("[WARN] serf: the response is close to the QueryResponseSizeLimit and might have been truncated")
 		}
 
 		// Currently only used for key list queries, this adds keys to a counter

--- a/serf/keymanager.go
+++ b/serf/keymanager.go
@@ -69,6 +69,7 @@ func (k *KeyManager) streamKeyResp(resp *KeyResponse, ch <-chan NodeResponse) {
 		}
 
 		if nodeResponse.Result && len(nodeResponse.Message) > 0 {
+			resp.Messages[r.From] = nodeResponse.Message
 			k.serf.logger.Println("[WARN] serf:", nodeResponse.Message)
 		}
 

--- a/website/source/docs/commands/keys.html.markdown
+++ b/website/source/docs/commands/keys.html.markdown
@@ -52,7 +52,7 @@ All operations are idempotent. The list of available flags are:
   installed. This is useful to operators to ensure that a given key has been
   installed on or removed from all members. It is possible that there are too
   many keys to fit into one message. In that case the reporting member truncates
-  the list until the message can be send. This is done to avoid not being able
+  the list until the message can be sent. This is done to avoid not being able
   to list the keys in case there are too many keys.
 
 * `-rpc-addr` - Address to the RPC server of the agent you want to contact

--- a/website/source/docs/commands/keys.html.markdown
+++ b/website/source/docs/commands/keys.html.markdown
@@ -50,7 +50,10 @@ All operations are idempotent. The list of available flags are:
   installed. After gathering keys from all members, the results will be returned
   in a summary showing each key and the number of members which have that key
   installed. This is useful to operators to ensure that a given key has been
-  installed on or removed from all members.
+  installed on or removed from all members. It is possible that there are too
+  many keys to fit into one message. In that case the reporting member truncates
+  the list until the message can be send. This is done to avoid not being able
+  to list the keys in case there are too many keys.
 
 * `-rpc-addr` - Address to the RPC server of the agent you want to contact
   to send this command. If this isn't specified, the command will contact


### PR DESCRIPTION
This truncates the list key response in case it contains too many keys so that the message would be bigger than allowed and serf wouldn't been able to send it out.

This is what it looks like if you run into it: 

```
2019/01/15 12:51:33 [INFO] serf: Received list-keys query
2019/01/15 12:51:33 [ERR] serf: Failed to respond to key query: response exceeds limit of 1024 bytes
```

If there are too many keys in a response, the keys will be removed from the end until it fits. That way the primary key (index 0) is always part of the response. In case of truncation there will be a warning, stating that it has been truncated. 
The receiving agent checks if the message is close to the limit and emit a warning about truncation as well.

I have to admit that this approach feels a little strange, but I think a truncated response is better than no response at all.