### PR TITLE
Fix data race on accessing `s.state` without `stateLock`

### DIFF
--- a/serf/serf.go
+++ b/serf/serf.go
@@ -1046,7 +1046,7 @@ func (s *Serf) handleNodeLeaveIntent(leaveMsg *messageLeave) bool {
 
 	// Refute us leaving if we are in the alive state
 	// Must be done in another goroutine since we have the memberLock
-	if leaveMsg.Node == s.config.NodeName && s.state == SerfAlive {
+	if leaveMsg.Node == s.config.NodeName && s.State() == SerfAlive {
 		s.logger.Printf("[DEBUG] serf: Refuting an older leave intent")
 		go s.broadcastJoin(s.clock.Time())
 		return false


### PR DESCRIPTION
Sample race:

```
WARNING: DATA RACE
Write at 0x00c0005f2eb8 by goroutine 136:
  /github.com/hashicorp/serf/serf.(*Serf).Leave()
      /github.com/hashicorp/serf/serf/serf.go:704 +0x3ce
  go-serf-agent%2egit.(*Agent).Leave()
      go-serf-agent.git/agent.go:286 +0xe3
  main.main.func1()
      main.go:338 +0x312

Previous read at 0x00c0005f2eb8 by goroutine 155:
  /github.com/hashicorp/serf/serf.(*Serf).handleNodeLeaveIntent()
      /github.com/hashicorp/serf/serf/serf.go:1049 +0x913
  /github.com/hashicorp/serf/serf.(*delegate).MergeRemoteState()
      /github.com/hashicorp/serf/serf/delegate.go:240 +0x3dc
  /github.com/hashicorp/memberlist.(*Memberlist).mergeRemoteState()
      /github.com/hashicorp/memberlist/net.go:1071 +0x7b9
  /github.com/hashicorp/memberlist.(*Memberlist).handleConn()
      /github.com/hashicorp/memberlist/net.go:264 +0xa3a
```

Every other access to `.state` seems to be synchronized except
for this one.

Way to reproduce: multiple concurrent leave requests.