### PR TITLE
Replace hashicorp/go-msgpack/codec with ugorji/go/codec

### DIFF
--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -9,9 +9,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/hashicorp/go-msgpack/codec"
 	"github.com/hashicorp/logutils"
 	"github.com/hashicorp/serf/coordinate"
+	"github.com/ugorji/go/codec"
 )
 
 const (
@@ -142,9 +142,13 @@ func ClientFromConfig(c *Config) (*RPCClient, error) {
 		shutdownCh: make(chan struct{}),
 	}
 	client.dec = codec.NewDecoder(client.reader,
-		&codec.MsgpackHandle{RawToString: true, WriteExt: true})
+		&codec.MsgpackHandle{
+			BasicHandle: codec.BasicHandle{DecodeOptions: codec.DecodeOptions{RawToString: true}},
+			WriteExt:    true})
 	client.enc = codec.NewEncoder(client.writer,
-		&codec.MsgpackHandle{RawToString: true, WriteExt: true})
+		&codec.MsgpackHandle{
+			BasicHandle: codec.BasicHandle{DecodeOptions: codec.DecodeOptions{RawToString: true}},
+			WriteExt:    true})
 	go client.listen()
 
 	// Do the initial handshake

--- a/cmd/serf/command/agent/ipc.go
+++ b/cmd/serf/command/agent/ipc.go
@@ -35,10 +35,10 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
-	"github.com/hashicorp/go-msgpack/codec"
 	"github.com/hashicorp/logutils"
 	"github.com/hashicorp/serf/coordinate"
 	"github.com/hashicorp/serf/serf"
+	"github.com/ugorji/go/codec"
 )
 
 const (
@@ -386,9 +386,13 @@ func (i *AgentIPC) listen() {
 			pendingQueries: make(map[uint64]*serf.Query),
 		}
 		client.dec = codec.NewDecoder(client.reader,
-			&codec.MsgpackHandle{RawToString: true, WriteExt: true})
+			&codec.MsgpackHandle{
+				BasicHandle: codec.BasicHandle{DecodeOptions: codec.DecodeOptions{RawToString: true}},
+				WriteExt:    true})
 		client.enc = codec.NewEncoder(client.writer,
-			&codec.MsgpackHandle{RawToString: true, WriteExt: true})
+			&codec.MsgpackHandle{
+				BasicHandle: codec.BasicHandle{DecodeOptions: codec.DecodeOptions{RawToString: true}},
+				WriteExt:    true})
 
 		// Register the client
 		i.Lock()

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/hashicorp/serf
 require (
 	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
 	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da
-	github.com/hashicorp/go-msgpack v0.5.3
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.1 // indirect
 	github.com/hashicorp/logutils v1.0.0
@@ -13,5 +12,6 @@ require (
 	github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee
 	github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f
 	github.com/stretchr/testify v1.3.0 // indirect
+	github.com/ugorji/go v1.1.4
 	golang.org/x/net v0.0.0-20181201002055-351d144fa1fc // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/ugorji/go v1.1.4 h1:j4s+tAvLfL3bZyefP2SEWmhBzmuIlH/eqNuPdFPgngw=
+github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3 h1:KYQXGkl6vs02hK7pK4eIbw0NpNPedieTSTEiJ//bwGs=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20181023162649-9b4f9f5ad519/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/serf/delegate.go
+++ b/serf/delegate.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"github.com/armon/go-metrics"
-	"github.com/hashicorp/go-msgpack/codec"
 	"github.com/hashicorp/memberlist"
+	"github.com/ugorji/go/codec"
 )
 
 // delegate is the memberlist.Delegate implementation that Serf uses.

--- a/serf/messages.go
+++ b/serf/messages.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/hashicorp/go-msgpack/codec"
+	"github.com/ugorji/go/codec"
 )
 
 // messageType are the types of gossip messages Serf will send along

--- a/serf/messages_test.go
+++ b/serf/messages_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/hashicorp/go-msgpack/codec"
+	"github.com/ugorji/go/codec"
 )
 
 func TestQueryFlags(t *testing.T) {

--- a/serf/ping_delegate.go
+++ b/serf/ping_delegate.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
-	"github.com/hashicorp/go-msgpack/codec"
 	"github.com/hashicorp/memberlist"
 	"github.com/hashicorp/serf/coordinate"
+	"github.com/ugorji/go/codec"
 )
 
 // pingDelegate is notified when memberlist successfully completes a direct ping

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -17,9 +17,9 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
-	"github.com/hashicorp/go-msgpack/codec"
 	"github.com/hashicorp/memberlist"
 	"github.com/hashicorp/serf/coordinate"
+	"github.com/ugorji/go/codec"
 )
 
 // These are the protocol versions that Serf can _understand_. These are
@@ -223,8 +223,8 @@ type queries struct {
 }
 
 const (
-	snapshotSizeLimit = 128 * 1024 // Maximum 128 KB snapshot
-	UserEventSizeLimit = 9 * 1024  // Maximum 9KB for event name and payload
+	snapshotSizeLimit  = 128 * 1024 // Maximum 128 KB snapshot
+	UserEventSizeLimit = 9 * 1024   // Maximum 9KB for event name and payload
 )
 
 // Create creates a new Serf instance, starting all the background tasks
@@ -445,7 +445,7 @@ func (s *Serf) KeyManager() *KeyManager {
 // If coalesce is enabled, nodes are allowed to coalesce this event.
 // Coalescing is only available starting in v0.2
 func (s *Serf) UserEvent(name string, payload []byte, coalesce bool) error {
-	payloadSizeBeforeEncoding := len(name)+len(payload)
+	payloadSizeBeforeEncoding := len(name) + len(payload)
 
 	// Check size before encoding to prevent needless encoding and return early if it's over the specified limit.
 	if payloadSizeBeforeEncoding > s.config.UserEventSizeLimit {

--- a/serf/serf_test.go
+++ b/serf/serf_test.go
@@ -12,10 +12,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-msgpack/codec"
 	"github.com/hashicorp/memberlist"
 	"github.com/hashicorp/serf/coordinate"
 	"github.com/hashicorp/serf/testutil"
+	"github.com/ugorji/go/codec"
 )
 
 func testConfig() *Config {


### PR DESCRIPTION
Prior to this being merged the corresponding memberlist PR should also be merged: https://github.com/hashicorp/memberlist/pull/193

Once that PR is merged and a new release is cut this PR will need to pull in that version of memberlist. Until that point in time this PR should not be merged.