### PR TITLE
Correct README about go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ https://www.serf.io/docs
 ## Developing Serf
 
 If you wish to work on Serf itself, you'll first need [Go](https://golang.org)
-installed (version 1.8+ is _required_). Make sure you have Go properly
+installed (version 1.10+ is _required_). Make sure you have Go properly
 [installed](https://golang.org/doc/install),
 including setting up your [GOPATH](https://golang.org/doc/code.html#GOPATH).
 


### PR DESCRIPTION
When I compile serf with go1.9 there are many error:# github.com/hashicorp/serf/vendor/github.com/miekg/dns
vendor/github.com/miekg/dns/dnssec_keyscan.go:295:7: undefined: strings.Builder
vendor/github.com/miekg/dns/msg_helpers.go:270:8: undefined: strings.Builder
vendor/github.com/miekg/dns/serve_mux.go:43:9: undefined: strings.Builder
vendor/github.com/miekg/dns/types.go:422:10: undefined: strings.Builder
....
while strings.Builder was added in go1.10 :)
