### PR TITLE
Bump encryption key size from 16 to 32 bytes

### DIFF
--- a/cmd/serf/command/agent/agent_test.go
+++ b/cmd/serf/command/agent/agent_test.go
@@ -222,9 +222,9 @@ func TestAgent_UnmarshalTagsError(t *testing.T) {
 
 func TestAgentKeyringFile(t *testing.T) {
 	keys := []string{
-		"enjTwAFRe4IE71bOFhirzQ==",
-		"csT9mxI7aTf9ap3HLBbdmA==",
-		"noha2tVc0OyD/2LtCBoAOQ==",
+		"HvY8ubRZMgafUOWvrOadwOckVa1wN3QWAo46FVKbVN8=",
+		"T9jncgl9mbLus+baTTa7q7nPSUrXwbDi2dhbtqir37s=",
+		"5K9OtfP7efFrNKe5WCQvXvnaXJ5cWP0SvXiwe0kkjM4=",
 	}
 
 	td, err := ioutil.TempDir("", "serf")
@@ -266,7 +266,7 @@ func TestAgentKeyringFile(t *testing.T) {
 func TestAgentKeyringFile_BadOptions(t *testing.T) {
 	agentConfig := DefaultConfig()
 	agentConfig.KeyringFile = "/some/path"
-	agentConfig.EncryptKey = "pL4owv4IE1x+ZXCyd5vLLg=="
+	agentConfig.EncryptKey = "5K9OtfP7efFrNKe5WCQvXvnaXJ5cWP0SvXiwe0kkjM4="
 
 	_, err := Create(agentConfig, serf.DefaultConfig(), nil)
 	if err == nil || !strings.Contains(err.Error(), "not allowed") {

--- a/cmd/serf/command/agent/command.go
+++ b/cmd/serf/command/agent/command.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
-	"github.com/hashicorp/go-syslog"
+	gsyslog "github.com/hashicorp/go-syslog"
 	"github.com/hashicorp/logutils"
 	"github.com/hashicorp/memberlist"
 	"github.com/hashicorp/serf/serf"
@@ -743,7 +743,7 @@ Options:
                            networks that support multicast, this can be used to have
                            peers join each other without an explicit join.
   -encrypt=foo             Key for encrypting network traffic within Serf.
-                           Must be a base64-encoded 16-byte key.
+                           Must be a base64-encoded 32-byte key.
   -keyring-file            The keyring file is used to store encryption keys used
                            by Serf. As encryption keys are changed, the content of
                            this file is updated so that the same keys may be used

--- a/cmd/serf/command/agent/config.go
+++ b/cmd/serf/command/agent/config.go
@@ -76,9 +76,9 @@ type Config struct {
 	AdvertiseAddr string `mapstructure:"advertise"`
 
 	// EncryptKey is the secret key to use for encrypting communication
-	// traffic for Serf. The secret key must be exactly 16-bytes, base64
+	// traffic for Serf. The secret key must be exactly 32-bytes, base64
 	// encoded. The easiest way to do this on Unix machines is this command:
-	// "head -c16 /dev/urandom | base64". If this is not specified, the
+	// "head -c32 /dev/urandom | base64". If this is not specified, the
 	// traffic will not be encrypted.
 	EncryptKey string `mapstructure:"encrypt_key"`
 

--- a/cmd/serf/command/agent/rpc_client_test.go
+++ b/cmd/serf/command/agent/rpc_client_test.go
@@ -830,7 +830,7 @@ func TestRPCClient_Keys_EncryptionDisabledError(t *testing.T) {
 	}
 
 	// Failed installing key
-	failures, err := client.InstallKey("El/H8lEqX2WiUa36SxcpZw==")
+	failures, err := client.InstallKey("5K9OtfP7efFrNKe5WCQvXvnaXJ5cWP0SvXiwe0kkjM4=")
 	if err == nil {
 		t.Fatalf("expected encryption disabled error")
 	}
@@ -839,7 +839,7 @@ func TestRPCClient_Keys_EncryptionDisabledError(t *testing.T) {
 	}
 
 	// Failed using key
-	failures, err = client.UseKey("El/H8lEqX2WiUa36SxcpZw==")
+	failures, err = client.UseKey("5K9OtfP7efFrNKe5WCQvXvnaXJ5cWP0SvXiwe0kkjM4=")
 	if err == nil {
 		t.Fatalf("expected encryption disabled error")
 	}
@@ -848,7 +848,7 @@ func TestRPCClient_Keys_EncryptionDisabledError(t *testing.T) {
 	}
 
 	// Failed removing key
-	failures, err = client.RemoveKey("El/H8lEqX2WiUa36SxcpZw==")
+	failures, err = client.RemoveKey("5K9OtfP7efFrNKe5WCQvXvnaXJ5cWP0SvXiwe0kkjM4=")
 	if err == nil {
 		t.Fatalf("expected encryption disabled error")
 	}
@@ -867,8 +867,8 @@ func TestRPCClient_Keys_EncryptionDisabledError(t *testing.T) {
 }
 
 func TestRPCClient_Keys(t *testing.T) {
-	newKey := "El/H8lEqX2WiUa36SxcpZw=="
-	existing := "A2xzjs0eq9PxSV2+dPi3sg=="
+	newKey := "5K9OtfP7efFrNKe5WCQvXvnaXJ5cWP0SvXiwe0kkjM4="
+	existing := "T9jncgl9mbLus+baTTa7q7nPSUrXwbDi2dhbtqir37s="
 	existingBytes, err := base64.StdEncoding.DecodeString(existing)
 	if err != nil {
 		t.Fatalf("err: %s", err)

--- a/cmd/serf/command/keygen.go
+++ b/cmd/serf/command/keygen.go
@@ -18,13 +18,13 @@ type KeygenCommand struct {
 var _ cli.Command = &KeygenCommand{}
 
 func (c *KeygenCommand) Run(_ []string) int {
-	key := make([]byte, 16)
+	key := make([]byte, 32)
 	n, err := rand.Reader.Read(key)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error reading random data: %s", err))
 		return 1
 	}
-	if n != 16 {
+	if n != 32 {
 		c.Ui.Error(fmt.Sprintf("Couldn't read enough entropy. Generate more entropy!"))
 		return 1
 	}

--- a/cmd/serf/command/keygen_test.go
+++ b/cmd/serf/command/keygen_test.go
@@ -21,7 +21,7 @@ func TestKeygenCommand(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	if len(result) != 16 {
+	if len(result) != 32 {
 		t.Fatalf("bad: %#v", result)
 	}
 }

--- a/cmd/serf/command/keys_test.go
+++ b/cmd/serf/command/keys_test.go
@@ -13,11 +13,11 @@ import (
 )
 
 func testKeysCommandAgent(t *testing.T) *agent.Agent {
-	key1, err := base64.StdEncoding.DecodeString("SNCg1bQSoCdGVlEx+TgfBw==")
+	key1, err := base64.StdEncoding.DecodeString("ZWTL+bgjHyQPhJRKcFe3ccirc2SFHmc/Nw67l8NQfdk=")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	key2, err := base64.StdEncoding.DecodeString("vbitCcJNwNP4aEWHgofjMg==")
+	key2, err := base64.StdEncoding.DecodeString("WbL6oaTPom+7RG7Q/INbJWKy09OLar/Hf2SuOAdoQE4=")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -52,13 +52,13 @@ func TestKeysCommandRun_InstallKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if _, ok := keys["jbuQMI4gMUeh1PPmKOtiBg=="]; ok {
+	if _, ok := keys["HvY8ubRZMgafUOWvrOadwOckVa1wN3QWAo46FVKbVN8="]; ok {
 		t.Fatalf("have test key")
 	}
 
 	args := []string{
 		"-rpc-addr=" + rpcAddr,
-		"-install", "jbuQMI4gMUeh1PPmKOtiBg==",
+		"-install", "HvY8ubRZMgafUOWvrOadwOckVa1wN3QWAo46FVKbVN8=",
 	}
 
 	code := c.Run(args)
@@ -74,7 +74,7 @@ func TestKeysCommandRun_InstallKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if _, ok := keys["jbuQMI4gMUeh1PPmKOtiBg=="]; !ok {
+	if _, ok := keys["HvY8ubRZMgafUOWvrOadwOckVa1wN3QWAo46FVKbVN8="]; !ok {
 		t.Fatalf("new key not found")
 	}
 }
@@ -91,7 +91,7 @@ func TestKeysCommandRun_InstallKeyFailure(t *testing.T) {
 	// Trying to install with encryption disabled returns 1
 	args := []string{
 		"-rpc-addr=" + rpcAddr,
-		"-install", "jbuQMI4gMUeh1PPmKOtiBg==",
+		"-install", "HvY8ubRZMgafUOWvrOadwOckVa1wN3QWAo46FVKbVN8=",
 	}
 
 	code := c.Run(args)
@@ -117,7 +117,7 @@ func TestKeysCommandRun_UseKey(t *testing.T) {
 	// Trying to use a non-existent key returns 1
 	args := []string{
 		"-rpc-addr=" + rpcAddr,
-		"-use", "eodFZZjm7pPwIZ0Miy7boQ==",
+		"-use", "T9jncgl9mbLus+baTTa7q7nPSUrXwbDi2dhbtqir37s=",
 	}
 
 	code := c.Run(args)
@@ -128,7 +128,7 @@ func TestKeysCommandRun_UseKey(t *testing.T) {
 	// Using an existing key returns 0
 	args = []string{
 		"-rpc-addr=" + rpcAddr,
-		"-use", "vbitCcJNwNP4aEWHgofjMg==",
+		"-use", "WbL6oaTPom+7RG7Q/INbJWKy09OLar/Hf2SuOAdoQE4=",
 	}
 
 	code = c.Run(args)
@@ -149,7 +149,7 @@ func TestKeysCommandRun_UseKeyFailure(t *testing.T) {
 	// Trying to use a key that doesn't exist returns 1
 	args := []string{
 		"-rpc-addr=" + rpcAddr,
-		"-use", "jbuQMI4gMUeh1PPmKOtiBg==",
+		"-use", "HvY8ubRZMgafUOWvrOadwOckVa1wN3QWAo46FVKbVN8=",
 	}
 
 	code := c.Run(args)
@@ -188,7 +188,7 @@ func TestKeysCommandRun_RemoveKey(t *testing.T) {
 	// Removing non-existing key still returns 0 (noop)
 	args := []string{
 		"-rpc-addr=" + rpcAddr,
-		"-remove", "eodFZZjm7pPwIZ0Miy7boQ==",
+		"-remove", "T9jncgl9mbLus+baTTa7q7nPSUrXwbDi2dhbtqir37s=",
 	}
 
 	code := c.Run(args)
@@ -208,7 +208,7 @@ func TestKeysCommandRun_RemoveKey(t *testing.T) {
 	// Removing a primary key returns 1
 	args = []string{
 		"-rpc-addr=" + rpcAddr,
-		"-remove", "SNCg1bQSoCdGVlEx+TgfBw==",
+		"-remove", "ZWTL+bgjHyQPhJRKcFe3ccirc2SFHmc/Nw67l8NQfdk=",
 	}
 
 	ui.ErrorWriter.Reset()
@@ -224,7 +224,7 @@ func TestKeysCommandRun_RemoveKey(t *testing.T) {
 	// Removing a non-primary, existing key returns 0
 	args = []string{
 		"-rpc-addr=" + rpcAddr,
-		"-remove", "vbitCcJNwNP4aEWHgofjMg==",
+		"-remove", "WbL6oaTPom+7RG7Q/INbJWKy09OLar/Hf2SuOAdoQE4=",
 	}
 
 	code = c.Run(args)
@@ -254,7 +254,7 @@ func TestKeysCommandRun_RemoveKeyFailure(t *testing.T) {
 	// Trying to remove the primary key returns 1
 	args := []string{
 		"-rpc-addr=" + rpcAddr,
-		"-remove", "SNCg1bQSoCdGVlEx+TgfBw==",
+		"-remove", "ZWTL+bgjHyQPhJRKcFe3ccirc2SFHmc/Nw67l8NQfdk=",
 	}
 
 	code := c.Run(args)
@@ -287,11 +287,11 @@ func TestKeysCommandRun_ListKeys(t *testing.T) {
 		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
 	}
 
-	if !strings.Contains(ui.OutputWriter.String(), "SNCg1bQSoCdGVlEx+TgfBw==") {
+	if !strings.Contains(ui.OutputWriter.String(), "ZWTL+bgjHyQPhJRKcFe3ccirc2SFHmc/Nw67l8NQfdk=") {
 		t.Fatalf("missing expected key")
 	}
 
-	if !strings.Contains(ui.OutputWriter.String(), "vbitCcJNwNP4aEWHgofjMg==") {
+	if !strings.Contains(ui.OutputWriter.String(), "WbL6oaTPom+7RG7Q/INbJWKy09OLar/Hf2SuOAdoQE4=") {
 		t.Fatalf("missing expected key")
 	}
 }
@@ -332,8 +332,8 @@ func TestKeysCommandRun_BadOptions(t *testing.T) {
 
 	args := []string{
 		"-rpc-addr=" + rpcAddr,
-		"-install", "vbitCcJNwNP4aEWHgofjMg==",
-		"-use", "vbitCcJNwNP4aEWHgofjMg==",
+		"-install", "WbL6oaTPom+7RG7Q/INbJWKy09OLar/Hf2SuOAdoQE4=",
+		"-use", "WbL6oaTPom+7RG7Q/INbJWKy09OLar/Hf2SuOAdoQE4=",
 	}
 
 	code := c.Run(args)
@@ -344,7 +344,7 @@ func TestKeysCommandRun_BadOptions(t *testing.T) {
 	args = []string{
 		"-rpc-addr=" + rpcAddr,
 		"-list",
-		"-remove", "SNCg1bQSoCdGVlEx+TgfBw==",
+		"-remove", "ZWTL+bgjHyQPhJRKcFe3ccirc2SFHmc/Nw67l8NQfdk=",
 	}
 
 	code = c.Run(args)

--- a/serf/internal_query_test.go
+++ b/serf/internal_query_test.go
@@ -93,7 +93,7 @@ func TestSerfQueries_estimateMaxKeysInListKeyResponseFactor(t *testing.T) {
 	q := Query{id: 0, serf: &Serf{config: &Config{NodeName: "", QueryResponseSizeLimit: DefaultConfig().QueryResponseSizeLimit * 10}}}
 	resp := nodeKeyResponse{Keys: []string{}}
 	for i := 0; i <= q.serf.config.QueryResponseSizeLimit; i++ {
-		resp.Keys = append(resp.Keys, "LeJcrRIZsZ9tPYJZW7Xllg==")
+		resp.Keys = append(resp.Keys, "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=")
 	}
 	found := 0
 	for i := len(resp.Keys); i >= 0; i-- {
@@ -129,19 +129,19 @@ func TestSerfQueries_keyListResponseWithCorrectSize(t *testing.T) {
 		hasMsg   bool
 	}{
 		{expected: 0, hasMsg: false, resp: nodeKeyResponse{}},
-		{expected: 1, hasMsg: false, resp: nodeKeyResponse{Keys: []string{"LeJcrRIZsZ9tPYJZW7Xllg=="}}},
+		{expected: 1, hasMsg: false, resp: nodeKeyResponse{Keys: []string{"KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg="}}},
 		// has 50 keys which makes the response bigger than 1024 bytes.
-		{expected: 36, hasMsg: true, resp: nodeKeyResponse{Keys: []string{
-			"LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==",
-			"LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==",
-			"LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==",
-			"LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==",
-			"LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==",
-			"LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==",
-			"LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==",
-			"LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==",
-			"LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==",
-			"LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==", "LeJcrRIZsZ9tPYJZW7Xllg==",
+		{expected: 19, hasMsg: true, resp: nodeKeyResponse{Keys: []string{
+			"KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=",
+			"KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=",
+			"KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=",
+			"KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=",
+			"KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=",
+			"KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=",
+			"KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=",
+			"KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=",
+			"KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=",
+			"KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=",
 		}}},
 	}
 	for _, c := range cases {

--- a/serf/keymanager_test.go
+++ b/serf/keymanager_test.go
@@ -11,9 +11,9 @@ import (
 
 func testKeyring() (*memberlist.Keyring, error) {
 	keys := []string{
-		"enjTwAFRe4IE71bOFhirzQ==",
-		"csT9mxI7aTf9ap3HLBbdmA==",
-		"noha2tVc0OyD/2LtCBoAOQ==",
+		"ZWTL+bgjHyQPhJRKcFe3ccirc2SFHmc/Nw67l8NQfdk=",
+		"WbL6oaTPom+7RG7Q/INbJWKy09OLar/Hf2SuOAdoQE4=",
+		"HvY8ubRZMgafUOWvrOadwOckVa1wN3QWAo46FVKbVN8=",
 	}
 
 	keysDecoded := make([][]byte, len(keys))
@@ -78,7 +78,7 @@ func TestSerf_InstallKey(t *testing.T) {
 	testutil.Yield()
 
 	// Begin tests
-	newKey := "l4ZkaypGLT8AsB0LBldthw=="
+	newKey := "HvY8ubRZMgafUOWvrOadwOckVa1wN3QWAo46FVKbVN8="
 	newKeyBytes, err := base64.StdEncoding.DecodeString(newKey)
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -134,7 +134,7 @@ func TestSerf_UseKey(t *testing.T) {
 	testutil.Yield()
 
 	// Begin tests
-	useKey := "csT9mxI7aTf9ap3HLBbdmA=="
+	useKey := "HvY8ubRZMgafUOWvrOadwOckVa1wN3QWAo46FVKbVN8="
 	useKeyBytes, err := base64.StdEncoding.DecodeString(useKey)
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -158,7 +158,7 @@ func TestSerf_UseKey(t *testing.T) {
 	}
 
 	// Make sure an error is thrown if the key doesn't exist
-	_, err = manager.UseKey("aE6AfGEvay+UJbkfxBk4SQ==")
+	_, err = manager.UseKey("T9jncgl9mbLus+baTTa7q7nPSUrXwbDi2dhbtqir37s=")
 	if err == nil {
 		t.Fatalf("Expected error changing to non-existent primary key")
 	}
@@ -186,7 +186,7 @@ func TestSerf_RemoveKey(t *testing.T) {
 	testutil.Yield()
 
 	// Begin tests
-	removeKey := "noha2tVc0OyD/2LtCBoAOQ=="
+	removeKey := "T9jncgl9mbLus+baTTa7q7nPSUrXwbDi2dhbtqir37s="
 	removeKeyBytes, err := base64.StdEncoding.DecodeString(removeKey)
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -228,7 +228,7 @@ func TestSerf_ListKeys(t *testing.T) {
 	initialKeyringLen := len(s1.config.MemberlistConfig.Keyring.GetKeys())
 
 	// Extra key on s2 to make sure we see it in the list
-	extraKey := "JHAxGU13qDaXhUW6jIpyog=="
+	extraKey := "5K9OtfP7efFrNKe5WCQvXvnaXJ5cWP0SvXiwe0kkjM4="
 	extraKeyBytes, err := base64.StdEncoding.DecodeString(extraKey)
 	if err != nil {
 		t.Fatalf("err: %s", err)

--- a/serf/serf_test.go
+++ b/serf/serf_test.go
@@ -1803,8 +1803,8 @@ func TestSerf_LocalMember(t *testing.T) {
 }
 
 func TestSerf_WriteKeyringFile(t *testing.T) {
-	existing := "jbuQMI4gMUeh1PPmKOtiBg=="
-	newKey := "eodFZZjm7pPwIZ0Miy7boQ=="
+	existing := "T9jncgl9mbLus+baTTa7q7nPSUrXwbDi2dhbtqir37s="
+	newKey := "HvY8ubRZMgafUOWvrOadwOckVa1wN3QWAo46FVKbVN8="
 
 	td, err := ioutil.TempDir("", "serf")
 	if err != nil {

--- a/website/source/docs/agent/encryption.html.markdown
+++ b/website/source/docs/agent/encryption.html.markdown
@@ -19,7 +19,7 @@ starting the Serf agent. The key can be set using the `-encrypt` flag
 on `serf agent` or by setting the `encrypt_key` in a configuration file.
 It is advisable to put the key in a configuration file to avoid other users
 from being able to discover it by inspecting running processes.
-The key must be 16-bytes that are base64 encoded. The easiest method to
+The key must be 32-bytes that are base64 encoded. The easiest method to
 obtain a cryptographically suitable key is by using `serf keygen`.
 
 ```

--- a/website/source/docs/agent/encryption.html.markdown
+++ b/website/source/docs/agent/encryption.html.markdown
@@ -24,14 +24,14 @@ obtain a cryptographically suitable key is by using `serf keygen`.
 
 ```
 $ serf keygen
-cg8StVXbQJ0gPvMd9o7yrg==
+pUqJrVyVRj5jsiYEkM/tFQYfWyJIv4s3XkvDwy7Cu5s=
 ```
 
 With that key, you can enable encryption on the agent. You can verify
 encryption is enabled because the output will include "Encrypted: true".
 
 ```
-$ serf agent -encrypt=cg8StVXbQJ0gPvMd9o7yrg==
+$ serf agent -encrypt=pUqJrVyVRj5jsiYEkM/tFQYfWyJIv4s3XkvDwy7Cu5s=
 ==> Starting Serf agent...
 ==> Serf agent running!
     Node name: 'mitchellh.local'

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -70,7 +70,7 @@ The options below are all specified on the command-line.
   environment that supports multicasting.
 
 * `-encrypt` - Specifies the secret key to use for encryption of Serf
-  network traffic. This key must be 16-bytes that are base64 encoded. The
+  network traffic. This key must be 32-bytes that are base64 encoded. The
   easiest way to create an encryption key is to use `serf keygen`. All
   nodes within a cluster must share the same encryption key to communicate.
 

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -330,9 +330,9 @@ file:
 
 ```javascript
 [
-  "QHOYjmYlxSCBhdfiolhtDQ==",
-  "daZ2wnuw+Ql+2hCm7vQB6A==",
-  "keTZydopxtiTY7HVoqeWGw=="
+  "HvY8ubRZMgafUOWvrOadwOckVa1wN3QWAo46FVKbVN8=",
+  "T9jncgl9mbLus+baTTa7q7nPSUrXwbDi2dhbtqir37s=",
+  "5K9OtfP7efFrNKe5WCQvXvnaXJ5cWP0SvXiwe0kkjM4="
 ]
 ```
 

--- a/website/source/docs/agent/rpc.html.markdown
+++ b/website/source/docs/agent/rpc.html.markdown
@@ -412,7 +412,7 @@ The request looks like:
     {"Key": "lkuIAePQcb/XGvuLPqwNtw=="}
 ```
 
-The `Key` must be 16 bytes of base64-encoded data. This value can be generated
+The `Key` must be 32 bytes of base64-encoded data. This value can be generated
 easily using the [keygen command](/docs/commands/keygen.html).
 
 Once invoked, this method will begin broadcasting the new key to all members in

--- a/website/source/docs/agent/rpc.html.markdown
+++ b/website/source/docs/agent/rpc.html.markdown
@@ -413,7 +413,7 @@ The request looks like:
 ```
 
 The `Key` must be 32 bytes of base64-encoded data. This value can be generated
-easily using the [keygen command](/docs/commands/keygen.html).
+using the [keygen command](/docs/commands/keygen.html).
 
 Once invoked, this method will begin broadcasting the new key to all members in
 the cluster via the gossip protocol. Once the query has completed, a response

--- a/website/source/docs/agent/rpc.html.markdown
+++ b/website/source/docs/agent/rpc.html.markdown
@@ -412,7 +412,7 @@ The request looks like:
     {"Key": "5K9OtfP7efFrNKe5WCQvXvnaXJ5cWP0SvXiwe0kkjM4="}
 ```
 
-The `Key` must be 32 bytes of base64-encoded data. This value can be generated
+The `Key` should be 32 bytes of base64-encoded data. `24` and `16` bytes are also accepted, but 32 bytes are recommended for improved security. This value can be generated
 using the [keygen command](/docs/commands/keygen.html).
 
 Once invoked, this method will begin broadcasting the new key to all members in

--- a/website/source/docs/agent/rpc.html.markdown
+++ b/website/source/docs/agent/rpc.html.markdown
@@ -409,7 +409,7 @@ cluster's keyring.
 The request looks like:
 
 ```
-    {"Key": "lkuIAePQcb/XGvuLPqwNtw=="}
+    {"Key": "5K9OtfP7efFrNKe5WCQvXvnaXJ5cWP0SvXiwe0kkjM4="}
 ```
 
 The `Key` must be 32 bytes of base64-encoded data. This value can be generated
@@ -445,7 +445,7 @@ messages.
 The request looks like:
 
 ```
-    {"Key": "lkuIAePQcb/XGvuLPqwNtw=="}
+    {"Key": "5K9OtfP7efFrNKe5WCQvXvnaXJ5cWP0SvXiwe0kkjM4="}
 ```
 
 The key requested must already exist in the keyring of all agents for this
@@ -462,7 +462,7 @@ The remove-key command is used to remove a key from the cluster's keyring.
 The request looks like:
 
 ```
-    {"Key": "lkuIAePQcb/XGvuLPqwNtw=="}
+    {"Key": "5K9OtfP7efFrNKe5WCQvXvnaXJ5cWP0SvXiwe0kkjM4="}
 ```
 
 The key requested must already exist in the keyring of each agent for this
@@ -489,8 +489,8 @@ There is no request body, but the response looks like:
             "node2": "message from node2"
         },
         "Keys": {
-            "lkuIAePQcb/XGvuLPqwNtw==": 2,
-            "FhADzydYiGiVz3vW7wpunQ==": 1
+            "5K9OtfP7efFrNKe5WCQvXvnaXJ5cWP0SvXiwe0kkjM4=": 2,
+            "T9jncgl9mbLus+baTTa7q7nPSUrXwbDi2dhbtqir37s=": 1
         },
         "NumErr": 0,
         "NumNodes": 2,

--- a/website/source/docs/internals/security.html.markdown
+++ b/website/source/docs/internals/security.html.markdown
@@ -27,7 +27,7 @@ All members of the Serf cluster must be provided the shared secret ahead of time
 This places the burden of key distribution on the user.
 
 To support confidentiality, all messages are encrypted using the
-[AES-128 standard](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard). The
+[AES-256 standard](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard). The
 AES standard is considered one of the most secure and modern encryption standards.
 Additionally, it is a fast algorithm, and modern CPUs provide hardware instructions to
 make encryption and decryption very lightweight.


### PR DESCRIPTION
This PR improves the security of the gossip protocol by increasing the size of the default encryption key used.