### PR TITLE
[lint] Fix linter warnings.

### DIFF
--- a/serf/keymanager_test.go
+++ b/serf/keymanager_test.go
@@ -255,7 +255,7 @@ func TestSerf_ListKeys(t *testing.T) {
 	}
 
 	found := false
-	for key, _ := range resp.Keys {
+	for key := range resp.Keys {
 		if key == extraKey {
 			found = true
 		}

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -223,8 +223,8 @@ type queries struct {
 }
 
 const (
-	snapshotSizeLimit = 128 * 1024 // Maximum 128 KB snapshot
-	UserEventSizeLimit = 9 * 1024  // Maximum 9KB for event name and payload
+	snapshotSizeLimit  = 128 * 1024 // Maximum 128 KB snapshot
+	UserEventSizeLimit = 9 * 1024   // Maximum 9KB for event name and payload
 )
 
 // Create creates a new Serf instance, starting all the background tasks
@@ -445,7 +445,7 @@ func (s *Serf) KeyManager() *KeyManager {
 // If coalesce is enabled, nodes are allowed to coalesce this event.
 // Coalescing is only available starting in v0.2
 func (s *Serf) UserEvent(name string, payload []byte, coalesce bool) error {
-	payloadSizeBeforeEncoding := len(name)+len(payload)
+	payloadSizeBeforeEncoding := len(name) + len(payload)
 
 	// Check size before encoding to prevent needless encoding and return early if it's over the specified limit.
 	if payloadSizeBeforeEncoding > s.config.UserEventSizeLimit {
@@ -1713,14 +1713,14 @@ func (s *Serf) Stats() map[string]string {
 	members := toString(uint64(len(s.members)))
 	failed := toString(uint64(len(s.failedMembers)))
 	left := toString(uint64(len(s.leftMembers)))
-	health_score := toString(uint64(s.memberlist.GetHealthScore()))
+	healthScore := toString(uint64(s.memberlist.GetHealthScore()))
 
 	s.memberLock.RUnlock()
 	stats := map[string]string{
 		"members":      members,
 		"failed":       failed,
 		"left":         left,
-		"health_score": health_score,
+		"health_score": healthScore,
 		"member_time":  toString(uint64(s.clock.Time())),
 		"event_time":   toString(uint64(s.eventClock.Time())),
 		"query_time":   toString(uint64(s.queryClock.Time())),

--- a/serf/serf_test.go
+++ b/serf/serf_test.go
@@ -500,7 +500,7 @@ func TestSerf_leaveRejoinDifferentRole(t *testing.T) {
 		t.Fatalf("s1 members: %d", len(s1.Members()))
 	}
 
-	var member *Member = nil
+	var member *Member
 	for _, m := range members {
 		if m.Name == s3Config.NodeName {
 			member = &m
@@ -672,7 +672,7 @@ func TestSerf_update(t *testing.T) {
 
 	// Add a tag to force an update event, and add a version downgrade as
 	// well (that alone won't trigger an update).
-	s2Config.ProtocolVersion -= 1
+	s2Config.ProtocolVersion--
 	s2Config.Tags["foo"] = "bar"
 
 	// We try for a little while to wait for s2 to fully shutdown since the
@@ -1414,31 +1414,31 @@ func TestSerf_SetTags(t *testing.T) {
 
 	// Verify the new tags
 	m1m := s1.Members()
-	m1m_tags := make(map[string]map[string]string)
+	m1mTags := make(map[string]map[string]string)
 	for _, m := range m1m {
-		m1m_tags[m.Name] = m.Tags
+		m1mTags[m.Name] = m.Tags
 	}
 
-	if m := m1m_tags[s1.config.NodeName]; m["port"] != "8000" {
-		t.Fatalf("bad: %v", m1m_tags)
+	if m := m1mTags[s1.config.NodeName]; m["port"] != "8000" {
+		t.Fatalf("bad: %v", m1mTags)
 	}
 
-	if m := m1m_tags[s2.config.NodeName]; m["datacenter"] != "east-aws" {
-		t.Fatalf("bad: %v", m1m_tags)
+	if m := m1mTags[s2.config.NodeName]; m["datacenter"] != "east-aws" {
+		t.Fatalf("bad: %v", m1mTags)
 	}
 
 	m2m := s2.Members()
-	m2m_tags := make(map[string]map[string]string)
+	m2mTags := make(map[string]map[string]string)
 	for _, m := range m2m {
-		m2m_tags[m.Name] = m.Tags
+		m2mTags[m.Name] = m.Tags
 	}
 
-	if m := m2m_tags[s1.config.NodeName]; m["port"] != "8000" {
-		t.Fatalf("bad: %v", m1m_tags)
+	if m := m2mTags[s1.config.NodeName]; m["port"] != "8000" {
+		t.Fatalf("bad: %v", m1mTags)
 	}
 
-	if m := m2m_tags[s2.config.NodeName]; m["datacenter"] != "east-aws" {
-		t.Fatalf("bad: %v", m1m_tags)
+	if m := m2mTags[s2.config.NodeName]; m["datacenter"] != "east-aws" {
+		t.Fatalf("bad: %v", m1mTags)
 	}
 }
 


### PR DESCRIPTION
This change resolves non-comment related issues reported by `go lint`
invocation.