### PR TITLE
Fix data race associated with serf state during leave

### DIFF
--- a/serf/serf.go
+++ b/serf/serf.go
@@ -1079,7 +1079,7 @@ func (s *Serf) handleNodeLeaveIntent(leaveMsg *messageLeave) bool {
 
 	// Refute us leaving if we are in the alive state
 	// Must be done in another goroutine since we have the memberLock
-	if leaveMsg.Node == s.config.NodeName && s.state == SerfAlive {
+	if leaveMsg.Node == s.config.NodeName && s.State() == SerfAlive {
 		s.logger.Printf("[DEBUG] serf: Refuting an older leave intent")
 		go s.broadcastJoin(s.clock.Time())
 		return false


### PR DESCRIPTION
Signed-off-by: girishsg24 <gangappa.girish@gmail.com>
Fixing the data race associated with serf state, accessed without acquiring the state mutex lock during handleNodeLeaveIntent. 

Attaching the data race  below.
==================
WARNING: DATA RACE
Write at 0x00c00038b1b8 by goroutine 204:
  github.com/hashicorp/serf/serf.(*Serf).Leave()
      /root/go/pkg/mod/github.com/hashicorp/serf@v0.8.3/serf/serf.go:737 +0x591
 ......

Previous read at 0x00c00038b1b8 by goroutine 115:
  github.com/hashicorp/serf/serf.(*Serf).handleNodeLeaveIntent()
      /root/go/pkg/mod/github.com/hashicorp/serf@v0.8.3/serf/serf.go:1082 +0x9c5
  github.com/hashicorp/serf/serf.(*delegate).MergeRemoteState()
      /root/go/pkg/mod/github.com/hashicorp/serf@v0.8.3/serf/delegate.go:240 +0x3dc
.....