### PR TITLE
Trigger Removal for Left/Failed Agents

### DIFF
--- a/client/const.go
+++ b/client/const.go
@@ -90,7 +90,8 @@ type eventRequest struct {
 }
 
 type forceLeaveRequest struct {
-	Node string
+	Node  string
+	Prune bool
 }
 
 type joinRequest struct {

--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -199,7 +199,8 @@ func (c *RPCClient) ForceLeave(node string) error {
 	return c.genericRPC(&header, &req, nil)
 }
 
-// If the prune flag is set, remove the node entirely
+//ForceLeavePrune uses ForceLeave but is used to reap the
+//node entirely
 func (c *RPCClient) ForceLeavePrune(node string) error {
 	header := requestHeader{
 		Command: forceLeaveCommand,

--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -187,14 +187,27 @@ func (c *RPCClient) Close() error {
 
 // ForceLeave is used to ask the agent to issue a leave command for
 // a given node
-func (c *RPCClient) ForceLeave(node string, prune bool) error {
+func (c *RPCClient) ForceLeave(node string) error {
 	header := requestHeader{
 		Command: forceLeaveCommand,
 		Seq:     c.getSeq(),
 	}
 	req := forceLeaveRequest{
 		Node:  node,
-		Prune: prune,
+		Prune: false,
+	}
+	return c.genericRPC(&header, &req, nil)
+}
+
+// If the prune flag is set, remove the node entirely
+func (c *RPCClient) ForceLeavePrune(node string) error {
+	header := requestHeader{
+		Command: forceLeaveCommand,
+		Seq:     c.getSeq(),
+	}
+	req := forceLeaveRequest{
+		Node:  node,
+		Prune: true,
 	}
 	return c.genericRPC(&header, &req, nil)
 }

--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -187,13 +187,14 @@ func (c *RPCClient) Close() error {
 
 // ForceLeave is used to ask the agent to issue a leave command for
 // a given node
-func (c *RPCClient) ForceLeave(node string) error {
+func (c *RPCClient) ForceLeave(node string, prune bool) error {
 	header := requestHeader{
 		Command: forceLeaveCommand,
 		Seq:     c.getSeq(),
 	}
 	req := forceLeaveRequest{
-		Node: node,
+		Node:  node,
+		Prune: prune,
 	}
 	return c.genericRPC(&header, &req, nil)
 }

--- a/cmd/serf/command/agent/agent.go
+++ b/cmd/serf/command/agent/agent.go
@@ -182,7 +182,7 @@ func (a *Agent) ForceLeave(node string) error {
 	return err
 }
 
-//ForceLeavePrune completely removes a failed node from the
+// ForceLeavePrune completely removes a failed node from the
 //member list entirely
 func (a *Agent) ForceLeavePrune(node string) error {
 	a.logger.Printf("[INFO] agent: Force leaving node: %s", node)

--- a/cmd/serf/command/agent/agent.go
+++ b/cmd/serf/command/agent/agent.go
@@ -185,10 +185,10 @@ func (a *Agent) ForceLeave(node string) error {
 // ForceLeavePrune completely removes a failed node from the
 // member list entirely
 func (a *Agent) ForceLeavePrune(node string) error {
-	a.logger.Printf("[INFO] agent: Force leaving node: %s", node)
+	a.logger.Printf("[INFO] agent: Force leaving node (prune): %s", node)
 	err := a.serf.RemoveFailedNodePrune(node)
 	if err != nil {
-		a.logger.Printf("[WARN] agent: failed to remove node: %v", err)
+		a.logger.Printf("[WARN] agent: failed to remove node (prune): %v", err)
 	}
 	return err
 }

--- a/cmd/serf/command/agent/agent.go
+++ b/cmd/serf/command/agent/agent.go
@@ -183,7 +183,7 @@ func (a *Agent) ForceLeave(node string) error {
 }
 
 // ForceLeavePrune completely removes a failed node from the
-//member list entirely
+// member list entirely
 func (a *Agent) ForceLeavePrune(node string) error {
 	a.logger.Printf("[INFO] agent: Force leaving node: %s", node)
 	err := a.serf.RemoveFailedNodePrune(node)

--- a/cmd/serf/command/agent/agent.go
+++ b/cmd/serf/command/agent/agent.go
@@ -173,9 +173,9 @@ func (a *Agent) Join(addrs []string, replay bool) (n int, err error) {
 }
 
 // ForceLeave is used to eject a failed node from the cluster
-func (a *Agent) ForceLeave(node string) error {
+func (a *Agent) ForceLeave(node string, prune bool) error {
 	a.logger.Printf("[INFO] agent: Force leaving node: %s", node)
-	err := a.serf.RemoveFailedNode(node)
+	err := a.serf.RemoveFailedNode(node, prune)
 	if err != nil {
 		a.logger.Printf("[WARN] agent: failed to remove node: %v", err)
 	}

--- a/cmd/serf/command/agent/agent.go
+++ b/cmd/serf/command/agent/agent.go
@@ -173,9 +173,20 @@ func (a *Agent) Join(addrs []string, replay bool) (n int, err error) {
 }
 
 // ForceLeave is used to eject a failed node from the cluster
-func (a *Agent) ForceLeave(node string, prune bool) error {
+func (a *Agent) ForceLeave(node string) error {
 	a.logger.Printf("[INFO] agent: Force leaving node: %s", node)
-	err := a.serf.RemoveFailedNode(node, prune)
+	err := a.serf.RemoveFailedNode(node)
+	if err != nil {
+		a.logger.Printf("[WARN] agent: failed to remove node: %v", err)
+	}
+	return err
+}
+
+//ForceLeavePrune completely removes a failed node from the
+//member list entirely
+func (a *Agent) ForceLeavePrune(node string) error {
+	a.logger.Printf("[INFO] agent: Force leaving node: %s", node)
+	err := a.serf.RemoveFailedNodePrune(node)
 	if err != nil {
 		a.logger.Printf("[WARN] agent: failed to remove node: %v", err)
 	}

--- a/cmd/serf/command/agent/ipc.go
+++ b/cmd/serf/command/agent/ipc.go
@@ -124,7 +124,8 @@ type eventRequest struct {
 }
 
 type forceLeaveRequest struct {
-	Node string
+	Node  string
+	Prune bool
 }
 
 type joinRequest struct {
@@ -605,7 +606,7 @@ func (i *AgentIPC) handleForceLeave(client *IPCClient, seq uint64) error {
 	}
 
 	// Attempt leave
-	err := i.agent.ForceLeave(req.Node)
+	err := i.agent.ForceLeave(req.Node, req.Prune)
 
 	// Respond
 	resp := responseHeader{

--- a/cmd/serf/command/agent/ipc.go
+++ b/cmd/serf/command/agent/ipc.go
@@ -606,18 +606,12 @@ func (i *AgentIPC) handleForceLeave(client *IPCClient, seq uint64) error {
 	}
 
 	// Attempt leave
+	var err error
 	if req.Prune {
-		err := i.agent.ForceLeavePrune(req.Node)
-
-		// Respond
-		resp := responseHeader{
-			Seq:   seq,
-			Error: errToString(err),
-		}
-		return client.Send(&resp, nil)
+		err = i.agent.ForceLeavePrune(req.Node)
+	} else {
+		err = i.agent.ForceLeave(req.Node)
 	}
-
-	err := i.agent.ForceLeave(req.Node)
 
 	// Respond
 	resp := responseHeader{

--- a/cmd/serf/command/agent/ipc.go
+++ b/cmd/serf/command/agent/ipc.go
@@ -606,7 +606,18 @@ func (i *AgentIPC) handleForceLeave(client *IPCClient, seq uint64) error {
 	}
 
 	// Attempt leave
-	err := i.agent.ForceLeave(req.Node, req.Prune)
+	if req.Prune {
+		err := i.agent.ForceLeavePrune(req.Node)
+
+		// Respond
+		resp := responseHeader{
+			Seq:   seq,
+			Error: errToString(err),
+		}
+		return client.Send(&resp, nil)
+	}
+
+	err := i.agent.ForceLeave(req.Node)
 
 	// Respond
 	resp := responseHeader{

--- a/cmd/serf/command/agent/rpc_client_test.go
+++ b/cmd/serf/command/agent/rpc_client_test.go
@@ -96,7 +96,7 @@ WAIT:
 		goto WAIT
 	}
 
-	if err := client.ForceLeave(a2.conf.NodeName, false); err != nil {
+	if err := client.ForceLeave(a2.conf.NodeName); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -152,7 +152,7 @@ WAIT:
 		goto WAIT
 	}
 
-	if err := client.ForceLeave(a2.conf.NodeName, true); err != nil {
+	if err := client.ForceLeavePrune(a2.conf.NodeName); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -164,7 +164,6 @@ WAIT:
 	}
 
 }
-
 
 func TestRPCClientJoin(t *testing.T) {
 	client, a1, ipc := testRPCClient(t)
@@ -330,7 +329,7 @@ func TestRPCClientMembersFiltered(t *testing.T) {
 	}
 
 	// Make sure that filters work on member status
-	if err := client.ForceLeave(a2.conf.NodeName, false); err != nil {
+	if err := client.ForceLeave(a2.conf.NodeName); err != nil {
 		t.Fatalf("bad: %s", err)
 	}
 

--- a/cmd/serf/command/agent/rpc_client_test.go
+++ b/cmd/serf/command/agent/rpc_client_test.go
@@ -117,16 +117,16 @@ func TestRPCClientForceLeave_prune(t *testing.T) {
 	a2 := testAgent(nil)
 	defer ipc.Shutdown()
 	defer client.Close()
-	defer a1.Shutdown()
-	defer a2.Shutdown()
 
 	if err := a1.Start(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	defer a1.Shutdown()
 
 	if err := a2.Start(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	defer a2.Shutdown()
 
 	testutil.Yield()
 

--- a/cmd/serf/command/force_leave.go
+++ b/cmd/serf/command/force_leave.go
@@ -17,8 +17,11 @@ type ForceLeaveCommand struct {
 var _ cli.Command = &ForceLeaveCommand{}
 
 func (c *ForceLeaveCommand) Run(args []string) int {
+	var prune bool
+
 	cmdFlags := flag.NewFlagSet("join", flag.ContinueOnError)
 	cmdFlags.Usage = func() { c.Ui.Output(c.Help()) }
+	cmdFlags.BoolVar(&prune, "prune", false, "Remove agent forcibly from list of members")
 	rpcAddr := RPCAddrFlag(cmdFlags)
 	rpcAuth := RPCAuthFlag(cmdFlags)
 	if err := cmdFlags.Parse(args); err != nil {
@@ -40,7 +43,7 @@ func (c *ForceLeaveCommand) Run(args []string) int {
 	}
 	defer client.Close()
 
-	err = client.ForceLeave(nodes[0])
+	err = client.ForceLeave(nodes[0], prune)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error force leaving: %s", err))
 		return 1
@@ -68,6 +71,7 @@ Options:
 
   -rpc-addr=127.0.0.1:7373  RPC address of the Serf agent.
   -rpc-auth=""              RPC auth token of the Serf agent.
+  -prune					Remove agent forcibly from list of members
 `
 	return strings.TrimSpace(helpText)
 }

--- a/cmd/serf/command/force_leave.go
+++ b/cmd/serf/command/force_leave.go
@@ -36,14 +36,24 @@ func (c *ForceLeaveCommand) Run(args []string) int {
 		return 1
 	}
 
-	client, err := RPCClient(*rpcAddr, *rpcAuth)
+	RPCClient, err := RPCClient(*rpcAddr, *rpcAuth)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error connecting to Serf agent: %s", err))
 		return 1
 	}
-	defer client.Close()
+	defer RPCClient.Close()
 
-	err = client.ForceLeave(nodes[0], prune)
+	if prune {
+		err = RPCClient.ForceLeavePrune(nodes[0])
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Error force leaving: %s", err))
+			return 1
+		}
+		return 0
+
+	}
+
+	err = RPCClient.ForceLeave(nodes[0])
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error force leaving: %s", err))
 		return 1

--- a/cmd/serf/command/force_leave.go
+++ b/cmd/serf/command/force_leave.go
@@ -71,7 +71,7 @@ Options:
 
   -rpc-addr=127.0.0.1:7373  RPC address of the Serf agent.
   -rpc-auth=""              RPC auth token of the Serf agent.
-  -prune					Remove agent forcibly from list of members
+  -prune                    Remove agent forcibly from list of members
 `
 	return strings.TrimSpace(helpText)
 }

--- a/cmd/serf/command/force_leave.go
+++ b/cmd/serf/command/force_leave.go
@@ -36,15 +36,15 @@ func (c *ForceLeaveCommand) Run(args []string) int {
 		return 1
 	}
 
-	RPCClient, err := RPCClient(*rpcAddr, *rpcAuth)
+	client, err := RPCClient(*rpcAddr, *rpcAuth)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error connecting to Serf agent: %s", err))
 		return 1
 	}
-	defer RPCClient.Close()
+	defer client.Close()
 
 	if prune {
-		err = RPCClient.ForceLeavePrune(nodes[0])
+		err = client.ForceLeavePrune(nodes[0])
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Error force leaving: %s", err))
 			return 1
@@ -53,7 +53,7 @@ func (c *ForceLeaveCommand) Run(args []string) int {
 
 	}
 
-	err = RPCClient.ForceLeave(nodes[0])
+	err = client.ForceLeave(nodes[0])
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error force leaving: %s", err))
 		return 1

--- a/cmd/serf/command/force_leave_test.go
+++ b/cmd/serf/command/force_leave_test.go
@@ -82,3 +82,55 @@ func TestForceLeaveCommandRun_noAddrs(t *testing.T) {
 		t.Fatalf("bad: %#v", ui.ErrorWriter.String())
 	}
 }
+
+func TestForceLeaveCommandRun_prune(t *testing.T) {
+	a1 := testAgent(t)
+	a2 := testAgent(t)
+	defer a1.Shutdown()
+	defer a2.Shutdown()
+	rpcAddr, ipc := testIPC(t, a1)
+	defer ipc.Shutdown()
+
+	_, err := a1.Join([]string{a2.SerfConfig().MemberlistConfig.BindAddr}, false)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	testutil.Yield()
+
+	// Forcibly shutdown a2 so that it appears "failed" in a1
+	if err := a2.Serf().Shutdown(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	start := time.Now()
+WAIT:
+	time.Sleep(a2.SerfConfig().MemberlistConfig.ProbeInterval * 3)
+	m := a1.Serf().Members()
+	if len(m) != 2 {
+		t.Fatalf("should have 2 members: %#v", a1.Serf().Members())
+	}
+
+	if m[1].Status != serf.StatusFailed && time.Now().Sub(start) < 3*time.Second {
+		goto WAIT
+	}
+
+	ui := new(cli.MockUi)
+	c := &ForceLeaveCommand{Ui: ui}
+	args := []string{
+		"-rpc-addr=" + rpcAddr,
+		"-prune",
+		a2.SerfConfig().NodeName,
+	}
+
+	code := c.Run(args)
+	if code != 0 {
+		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
+	}
+
+	m = a1.Serf().Members()
+	if len(m) != 1 {
+		t.Fatalf("should have 1 members: %#v", a1.Serf().Members())
+	}
+
+}

--- a/serf/messages.go
+++ b/serf/messages.go
@@ -55,6 +55,7 @@ type messageJoin struct {
 type messageLeave struct {
 	LTime LamportTime
 	Node  string
+	Prune bool
 }
 
 // messagePushPullType is used when doing a state exchange. This

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -781,11 +781,28 @@ func (s *Serf) Members() []Member {
 	return members
 }
 
-// RemoveFailedNode forcibly removes a failed node from the cluster
+//RemoveFailedNode is a backwards compatabile form
+// of ForceLeave
+func (s *Serf) RemoveFailedNode(node string) error {
+	if err := s.ForceLeave(node, false); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Serf) RemoveFailedNodePrune(node string) error {
+	if err := s.ForceLeave(node, true); err != nil {
+		return err
+	}
+	return nil
+
+}
+
+// ForceLeave forcibly removes a failed node from the cluster
 // immediately, instead of waiting for the reaper to eventually reclaim it.
 // This also has the effect that Serf will no longer attempt to reconnect
 // to this node.
-func (s *Serf) RemoveFailedNode(node string, prune bool) error {
+func (s *Serf) ForceLeave(node string, prune bool) error {
 	// Construct the message to broadcast
 	msg := messageLeave{
 		LTime: s.clock.Time(),

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -781,7 +781,7 @@ func (s *Serf) Members() []Member {
 	return members
 }
 
-//RemoveFailedNode is a backwards compatabile form
+// RemoveFailedNode is a backwards compatible form
 // of ForceLeave
 func (s *Serf) RemoveFailedNode(node string) error {
 	if err := s.ForceLeave(node, false); err != nil {

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -1470,7 +1470,7 @@ func (s *Serf) handlePrune(old []*memberState, m *memberState) []*memberState {
 	}
 
 	// Send an event along
-	s.logger.Printf("[INFO] serf: EventMemberReap: %s", m.Name)
+	s.logger.Printf("[INFO] serf: EventMemberReap (forced): %s", m.Name)
 	if s.config.EventCh != nil {
 		s.config.EventCh <- MemberEvent{
 			Type:    EventMemberReap,

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -1453,7 +1453,7 @@ func (s *Serf) resolveNodeConflict() {
 	}
 }
 
-//handlePrune is a simplified version of Reap() which only runs when the prune
+// handlePrune is a simplified version of Reap() which only runs when the prune
 //flag is set
 func (s *Serf) handlePrune(old []*memberState, m *memberState) []*memberState {
 	// Delete from members

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -1121,6 +1121,13 @@ func (s *Serf) handleNodeLeaveIntent(leaveMsg *messageLeave) bool {
 		}
 
 		return true
+
+	case StatusLeft:
+		if leaveMsg.Prune {
+			s.handlePrune(s.leftMembers, member)
+		}
+		return true
+
 	default:
 		return false
 	}

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -1471,7 +1471,7 @@ func (s *Serf) resolveNodeConflict() {
 }
 
 // handlePrune is a simplified version of Reap() which only runs when the prune
-//flag is set
+// flag is set
 func (s *Serf) handlePrune(old []*memberState, m *memberState) []*memberState {
 	// Delete from members
 	delete(s.members, m.Name)

--- a/serf/serf_test.go
+++ b/serf/serf_test.go
@@ -250,7 +250,7 @@ func TestSerf_RemoveFailed_eventsLeave(t *testing.T) {
 
 	time.Sleep(s2Config.MemberlistConfig.ProbeInterval * 3)
 
-	if err := s1.RemoveFailedNode(s2Config.NodeName); err != nil {
+	if err := s1.RemoveFailedNode(s2Config.NodeName, false); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -827,13 +827,75 @@ func TestSerfRemoveFailedNode(t *testing.T) {
 	testMember(t, s1.Members(), s2Config.NodeName, StatusFailed)
 
 	// Now remove the failed node
-	if err := s1.RemoveFailedNode(s2Config.NodeName); err != nil {
+	if err := s1.RemoveFailedNode(s2Config.NodeName, false); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
 	// Verify that s2 is gone
 	testMember(t, s1.Members(), s2Config.NodeName, StatusLeft)
 	testMember(t, s3.Members(), s2Config.NodeName, StatusLeft)
+}
+
+func TestSerfRemoveFailedNode_prune(t *testing.T) {
+	s1Config := testConfig()
+	s2Config := testConfig()
+	s3Config := testConfig()
+
+	s1, err := Create(s1Config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	s2, err := Create(s2Config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	s3, err := Create(s3Config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	defer s1.Shutdown()
+	defer s2.Shutdown()
+	defer s3.Shutdown()
+
+	_, err = s1.Join([]string{s2Config.MemberlistConfig.BindAddr}, false)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	_, err = s1.Join([]string{s3Config.MemberlistConfig.BindAddr}, false)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	testutil.Yield()
+
+	// Now force the shutdown of s2 so it appears to fail.
+	if err := s2.Shutdown(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	time.Sleep(s2Config.MemberlistConfig.ProbeInterval * 5)
+
+	// Verify that s2 is "failed"
+	testMember(t, s1.Members(), s2Config.NodeName, StatusFailed)
+
+	// Now remove the failed node
+	if err := s1.RemoveFailedNode(s2Config.NodeName, true); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Check to make sure it's gone
+	if len(s1.Members()) != 2 {
+		t.Fatalf("err: numbers of members should be two, found %v", len(s1.Members()))
+	}
+
+	if len(s3.Members()) != 2 {
+		t.Fatalf("err: numbers of members should be two, found %v", len(s3.Members()))
+	}
+
 }
 
 func TestSerfRemoveFailedNode_ourself(t *testing.T) {
@@ -846,7 +908,7 @@ func TestSerfRemoveFailedNode_ourself(t *testing.T) {
 
 	testutil.Yield()
 
-	if err := s1.RemoveFailedNode("somebody"); err != nil {
+	if err := s1.RemoveFailedNode("somebody", false); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 }
@@ -1275,7 +1337,7 @@ func TestSerf_SnapshotRecovery(t *testing.T) {
 	testMember(t, s1.Members(), s2Config.NodeName, StatusFailed)
 
 	// Now remove the failed node
-	if err := s1.RemoveFailedNode(s2Config.NodeName); err != nil {
+	if err := s1.RemoveFailedNode(s2Config.NodeName, false); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/serf/serf_test.go
+++ b/serf/serf_test.go
@@ -250,7 +250,7 @@ func TestSerf_RemoveFailed_eventsLeave(t *testing.T) {
 
 	time.Sleep(s2Config.MemberlistConfig.ProbeInterval * 3)
 
-	if err := s1.RemoveFailedNode(s2Config.NodeName, false); err != nil {
+	if err := s1.RemoveFailedNode(s2Config.NodeName); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -827,7 +827,7 @@ func TestSerfRemoveFailedNode(t *testing.T) {
 	testMember(t, s1.Members(), s2Config.NodeName, StatusFailed)
 
 	// Now remove the failed node
-	if err := s1.RemoveFailedNode(s2Config.NodeName, false); err != nil {
+	if err := s1.RemoveFailedNode(s2Config.NodeName); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -845,19 +845,18 @@ func TestSerfRemoveFailedNode_prune(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	defer s1.Shutdown()
 
 	s2, err := Create(s2Config)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	defer s2.Shutdown()
 
 	s3, err := Create(s3Config)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-
-	defer s1.Shutdown()
-	defer s2.Shutdown()
 	defer s3.Shutdown()
 
 	_, err = s1.Join([]string{s2Config.MemberlistConfig.BindAddr}, false)
@@ -883,7 +882,7 @@ func TestSerfRemoveFailedNode_prune(t *testing.T) {
 	testMember(t, s1.Members(), s2Config.NodeName, StatusFailed)
 
 	// Now remove the failed node
-	if err := s1.RemoveFailedNode(s2Config.NodeName, true); err != nil {
+	if err := s1.RemoveFailedNodePrune(s2Config.NodeName); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -908,7 +907,7 @@ func TestSerfRemoveFailedNode_ourself(t *testing.T) {
 
 	testutil.Yield()
 
-	if err := s1.RemoveFailedNode("somebody", false); err != nil {
+	if err := s1.RemoveFailedNode("somebody"); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 }
@@ -1337,7 +1336,7 @@ func TestSerf_SnapshotRecovery(t *testing.T) {
 	testMember(t, s1.Members(), s2Config.NodeName, StatusFailed)
 
 	// Now remove the failed node
-	if err := s1.RemoveFailedNode(s2Config.NodeName, false); err != nil {
+	if err := s1.RemoveFailedNode(s2Config.NodeName); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/website/source/docs/commands/force-leave.html.markdown
+++ b/website/source/docs/commands/force-leave.html.markdown
@@ -38,4 +38,7 @@ Every option is optional:
   command. This option can also be controlled using the `SERF_RPC_AUTH`
   environment variable.
 
+* `-prune` -  Forcibly removes a member of the Serf cluster from the member
+list completely
+
 


### PR DESCRIPTION
Adds the `-prune` flag to the `forceleave` command to allow for an agent to be completely removed from Serf's list of members. This can only be ran with the force leave command, so this can only be ran on nodes in a failed or left state. 
