### PR TITLE
tests: normalize and unflake a bunch of tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,8 @@ jobs:
           keys:
             - serf-modcache-v1-{{ checksum "go.mod" }}
 
+      - run: sudo apt-get update && sudo apt-get install -y rsyslog
+      - run: sudo service rsyslog start
       # run go tests with gotestsum
       - run: |
           PACKAGE_NAMES=$(go list ./...)

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ website/build/
 website/.bundle
 website/vendor
 .vagrant
+/coverage.out

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,65 +1,63 @@
-GOTOOLS = github.com/mitchellh/gox
-VERSION = $(shell awk -F\" '/^const Version/ { print $$2; exit }' cmd/serf/version.go)
+SHELL := bash
+
+GOTOOLS := github.com/mitchellh/gox
+VERSION := $(shell awk -F\" '/^const Version/ { print $$2; exit }' cmd/serf/version.go)
 GITSHA:=$(shell git rev-parse HEAD)
 GITBRANCH:=$(shell git symbolic-ref --short HEAD 2>/dev/null)
 
-default:: test
+GOFILES ?= $(shell go list ./... | grep -v /vendor/)
+
+default: test
 
 # bin generates the releasable binaries
-bin:: tools
+bin: tools
 	@sh -c "'$(CURDIR)/scripts/build.sh'"
 
-# cov generates the coverage output
-cov:: tools
-	gocov test ./... | gocov-html > /tmp/coverage.html
-	open /tmp/coverage.html
+cov:
+	go test ./... -coverprofile=coverage.out
+	go tool cover -html=coverage.out
+
+format:
+	@echo "--> Running go fmt"
+	@go fmt $(GOFILES)
 
 # dev creates binaries for testing locally - these are put into ./bin and
 # $GOPATH
-dev::
+dev:
 	@SERF_DEV=1 sh -c "'$(CURDIR)/scripts/build.sh'"
 
 # dist creates the binaries for distibution
-dist::
+dist:
 	@sh -c "'$(CURDIR)/scripts/dist.sh' $(VERSION)"
 
-get-tools::
+get-tools:
 	go get -u -v $(GOTOOLS)
 
 # subnet sets up the require subnet for testing on darwin (osx) - you must run
 # this before running other tests if you are on osx.
-subnet::
+subnet:
 	@sh -c "'$(CURDIR)/scripts/setup_test_subnet.sh'"
 
 # test runs the test suite
-test:: subnet tools
-	@go list ./... | xargs -n1 go test $(TESTARGS)
+test: subnet vet
+	go test ./...
 
 # testrace runs the race checker
-testrace:: subnet
+testrace: subnet vet
 	go test -race ./... $(TESTARGS)
 
-tools::
+tools:
 	@which gox 2>/dev/null ; if [ $$? -eq 1 ]; then \
 		$(MAKE) get-tools; \
 	fi
 
-# updatedeps installs all the dependencies needed to test, build, and run
-updatedeps:: tools
-	go get -u
-	go mod tidy
-	go mod vendor
-
-vet:: tools
-	@echo "--> Running go tool vet $(VETARGS) ."
-	@go list ./... \
-		| cut -d '/' -f 4- \
-		| xargs -n1 \
-			go tool vet $(VETARGS) ;\
-	if [ $$? -ne 0 ]; then \
+vet:
+	@echo "--> Running go vet"
+	@go vet -tags '$(GOTAGS)' $(GOFILES); if [ $$? -eq 1 ]; then \
 		echo ""; \
 		echo "Vet found suspicious constructs. Please check the reported constructs"; \
-		echo "and fix them if necessary before submitting the code for reviewal."; \
+		echo "and fix them if necessary before submitting the code for review."; \
+		exit 1; \
 	fi
 
-.PHONY: default bin cov dev dist get-tools subnet test testrace tools updatedeps vet
+.PHONY: default bin cov format dev dist get-tools subnet test testrace tools vet

--- a/cmd/serf/command/agent/config_test.go
+++ b/cmd/serf/command/agent/config_test.go
@@ -51,7 +51,7 @@ func TestConfigEncryptBytes(t *testing.T) {
 
 	result, err := c.EncryptBytes()
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if !bytes.Equal(src, result) {
@@ -62,7 +62,7 @@ func TestConfigEncryptBytes(t *testing.T) {
 	c = &Config{}
 	result, err = c.EncryptBytes()
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if len(result) > 0 {
@@ -98,7 +98,7 @@ func TestDecodeConfig(t *testing.T) {
 	input := `{"node_name": "foo"}`
 	config, err := DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if config.NodeName != "foo" {
@@ -121,7 +121,7 @@ func TestDecodeConfig(t *testing.T) {
 	input = `{"node_name": "foo", "protocol": 7}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if config.NodeName != "foo" {
@@ -136,7 +136,7 @@ func TestDecodeConfig(t *testing.T) {
 	input = `{"bind": "127.0.0.2"}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if config.BindAddr != "127.0.0.2" {
@@ -147,7 +147,7 @@ func TestDecodeConfig(t *testing.T) {
 	input = `{"replay_on_join": true}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if config.ReplayOnJoin != true {
@@ -158,7 +158,7 @@ func TestDecodeConfig(t *testing.T) {
 	input = `{"leave_on_terminate": true}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if config.LeaveOnTerm != true {
@@ -169,7 +169,7 @@ func TestDecodeConfig(t *testing.T) {
 	input = `{"skip_leave_on_interrupt": true}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if config.SkipLeaveOnInt != true {
@@ -180,7 +180,7 @@ func TestDecodeConfig(t *testing.T) {
 	input = `{"tags": {"foo": "bar", "role": "test"}}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if config.Tags["foo"] != "bar" {
@@ -194,7 +194,7 @@ func TestDecodeConfig(t *testing.T) {
 	input = `{"tags_file": "/some/path"}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if config.TagsFile != "/some/path" {
@@ -205,7 +205,7 @@ func TestDecodeConfig(t *testing.T) {
 	input = `{"discover": "foobar"}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if config.Discover != "foobar" {
@@ -216,7 +216,7 @@ func TestDecodeConfig(t *testing.T) {
 	input = `{"interface": "eth0"}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if config.Interface != "eth0" {
@@ -227,7 +227,7 @@ func TestDecodeConfig(t *testing.T) {
 	input = `{"reconnect_interval": "15s", "reconnect_timeout": "48h"}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if config.ReconnectInterval != 15*time.Second {
@@ -242,7 +242,7 @@ func TestDecodeConfig(t *testing.T) {
 	input = `{"rpc_auth": "foobar"}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if config.RPCAuthKey != "foobar" {
@@ -253,7 +253,7 @@ func TestDecodeConfig(t *testing.T) {
 	input = `{"disable_name_resolution": true}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if !config.DisableNameResolution {
@@ -264,7 +264,7 @@ func TestDecodeConfig(t *testing.T) {
 	input = `{"tombstone_timeout": "48h"}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if config.TombstoneTimeout != 48*time.Hour {
@@ -275,7 +275,7 @@ func TestDecodeConfig(t *testing.T) {
 	input = `{"enable_syslog": true, "syslog_facility": "LOCAL4"}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if !config.EnableSyslog {
@@ -289,7 +289,7 @@ func TestDecodeConfig(t *testing.T) {
 	input = `{"retry_max_attempts": 5, "retry_interval": "60s"}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if config.RetryMaxAttempts != 5 {
@@ -304,7 +304,7 @@ func TestDecodeConfig(t *testing.T) {
 	input = `{"broadcast_timeout": "10s"}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if config.BroadcastTimeout != 10*time.Second {
@@ -315,7 +315,7 @@ func TestDecodeConfig(t *testing.T) {
 	input = `{"retry_join": ["127.0.0.1", "127.0.0.2"]}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if len(config.RetryJoin) != 2 {
@@ -334,7 +334,7 @@ func TestDecodeConfig(t *testing.T) {
 	input = `{"rejoin_after_leave": true}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if !config.RejoinAfterLeave {
@@ -345,7 +345,7 @@ func TestDecodeConfig(t *testing.T) {
 	input = `{"statsite_addr": "127.0.0.1:8123", "statsd_addr": "127.0.0.1:8125"}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if config.StatsiteAddr != "127.0.0.1:8123" {
@@ -360,7 +360,7 @@ func TestDecodeConfig(t *testing.T) {
 	input = `{"query_response_size_limit": 123, "query_size_limit": 456}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if config.QueryResponseSizeLimit != 123 || config.QuerySizeLimit != 456 {
@@ -534,7 +534,7 @@ func TestReadConfigPaths_badPath(t *testing.T) {
 func TestReadConfigPaths_file(t *testing.T) {
 	tf, err := ioutil.TempFile("", "serf")
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 	tf.Write([]byte(`{"node_name":"bar"}`))
 	tf.Close()
@@ -542,7 +542,7 @@ func TestReadConfigPaths_file(t *testing.T) {
 
 	config, err := ReadConfigPaths([]string{tf.Name()})
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if config.NodeName != "bar" {
@@ -553,32 +553,32 @@ func TestReadConfigPaths_file(t *testing.T) {
 func TestReadConfigPaths_dir(t *testing.T) {
 	td, err := ioutil.TempDir("", "serf")
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 	defer os.RemoveAll(td)
 
 	err = ioutil.WriteFile(filepath.Join(td, "a.json"),
 		[]byte(`{"node_name": "bar"}`), 0644)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	err = ioutil.WriteFile(filepath.Join(td, "b.json"),
 		[]byte(`{"node_name": "baz"}`), 0644)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	// A non-json file, shouldn't be read
 	err = ioutil.WriteFile(filepath.Join(td, "c"),
 		[]byte(`{"node_name": "bad"}`), 0644)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	config, err := ReadConfigPaths([]string{td})
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if config.NodeName != "baz" {

--- a/cmd/serf/command/agent/event_handler_test.go
+++ b/cmd/serf/command/agent/event_handler_test.go
@@ -50,24 +50,24 @@ done
 func testEventScript(t *testing.T, script string) (string, string) {
 	scriptFile, err := ioutil.TempFile("", "serf")
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 	defer scriptFile.Close()
 
 	if err := scriptFile.Chmod(0755); err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	resultFile, err := ioutil.TempFile("", "serf-result")
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 	defer resultFile.Close()
 
 	_, err = scriptFile.Write([]byte(
 		fmt.Sprintf(script, resultFile.Name())))
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	return scriptFile.Name(), resultFile.Name()
@@ -110,7 +110,7 @@ func TestScriptEventHandler(t *testing.T) {
 
 	result, err := ioutil.ReadFile(results)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	expected1 := "ourname ourrole\neast-aws\nbad\nmember-join\nos-env-foo\nfoo\t1.2.3.4\tbar\trole=bar,foo=bar\n"
@@ -151,7 +151,7 @@ func TestScriptUserEventHandler(t *testing.T) {
 
 	result, err := ioutil.ReadFile(results)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	expected := "ourname ourrole\neast-aws\nuser baz\nuser 1\nfoobar\n"
@@ -190,7 +190,7 @@ func TestScriptQueryEventHandler(t *testing.T) {
 
 	result, err := ioutil.ReadFile(results)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	expected := "ourname ourrole\neast-aws\nquery uptime\nquery 42\nload average\n"

--- a/cmd/serf/command/agent/flag_slice_value_test.go
+++ b/cmd/serf/command/agent/flag_slice_value_test.go
@@ -9,12 +9,12 @@ func TestAppendSliceValueSet(t *testing.T) {
 	sv := new(AppendSliceValue)
 	err := sv.Set("foo")
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	err = sv.Set("bar")
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	expected := []string{"foo", "bar"}

--- a/cmd/serf/command/agent/syslog_test.go
+++ b/cmd/serf/command/agent/syslog_test.go
@@ -14,7 +14,7 @@ func TestSyslogFilter(t *testing.T) {
 	}
 	l, err := gsyslog.NewLogger(gsyslog.LOG_NOTICE, "LOCAL0", "serf")
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	filt := LevelFilter()
@@ -23,7 +23,7 @@ func TestSyslogFilter(t *testing.T) {
 	s := &SyslogWrapper{l, filt}
 	n, err := s.Write([]byte("[INFO] test"))
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 	if n == 0 {
 		t.Fatalf("should have logged")
@@ -31,7 +31,7 @@ func TestSyslogFilter(t *testing.T) {
 
 	n, err = s.Write([]byte("[DEBUG] test"))
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 	if n != 0 {
 		t.Fatalf("should not have logged")

--- a/cmd/serf/command/force_leave_test.go
+++ b/cmd/serf/command/force_leave_test.go
@@ -11,23 +11,34 @@ import (
 )
 
 func TestForceLeaveCommandRun(t *testing.T) {
-	a1 := testAgent(t)
-	a2 := testAgent(t)
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	ip3, returnFn3 := testutil.TakeIP()
+	defer returnFn3()
+
+	a1 := testAgent(t, ip1)
 	defer a1.Shutdown()
+
+	a2 := testAgent(t, ip2)
 	defer a2.Shutdown()
-	rpcAddr, ipc := testIPC(t, a1)
+
+	rpcAddr, ipc := testIPC(t, ip3, a1)
 	defer ipc.Shutdown()
 
 	_, err := a1.Join([]string{a2.SerfConfig().MemberlistConfig.BindAddr}, false)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	testutil.Yield()
 
 	// Forcibly shutdown a2 so that it appears "failed" in a1
 	if err := a2.Serf().Shutdown(); err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	start := time.Now()
@@ -84,23 +95,34 @@ func TestForceLeaveCommandRun_noAddrs(t *testing.T) {
 }
 
 func TestForceLeaveCommandRun_prune(t *testing.T) {
-	a1 := testAgent(t)
-	a2 := testAgent(t)
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	ip3, returnFn3 := testutil.TakeIP()
+	defer returnFn3()
+
+	a1 := testAgent(t, ip1)
 	defer a1.Shutdown()
+
+	a2 := testAgent(t, ip2)
 	defer a2.Shutdown()
-	rpcAddr, ipc := testIPC(t, a1)
+
+	rpcAddr, ipc := testIPC(t, ip3, a1)
 	defer ipc.Shutdown()
 
 	_, err := a1.Join([]string{a2.SerfConfig().MemberlistConfig.BindAddr}, false)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	testutil.Yield()
 
 	// Forcibly shutdown a2 so that it appears "failed" in a1
 	if err := a2.Serf().Shutdown(); err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	start := time.Now()

--- a/cmd/serf/command/info_test.go
+++ b/cmd/serf/command/info_test.go
@@ -4,13 +4,21 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/serf/testutil"
 	"github.com/mitchellh/cli"
 )
 
 func TestInfoCommandRun(t *testing.T) {
-	a1 := testAgent(t)
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	a1 := testAgent(t, ip1)
 	defer a1.Shutdown()
-	rpcAddr, ipc := testIPC(t, a1)
+
+	rpcAddr, ipc := testIPC(t, ip2, a1)
 	defer ipc.Shutdown()
 
 	ui := new(cli.MockUi)

--- a/cmd/serf/command/join_test.go
+++ b/cmd/serf/command/join_test.go
@@ -4,15 +4,27 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/serf/testutil"
 	"github.com/mitchellh/cli"
 )
 
 func TestJoinCommandRun(t *testing.T) {
-	a1 := testAgent(t)
-	a2 := testAgent(t)
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	ip3, returnFn3 := testutil.TakeIP()
+	defer returnFn3()
+
+	a1 := testAgent(t, ip1)
 	defer a1.Shutdown()
+
+	a2 := testAgent(t, ip2)
 	defer a2.Shutdown()
-	rpcAddr, ipc := testIPC(t, a1)
+
+	rpcAddr, ipc := testIPC(t, ip3, a1)
 	defer ipc.Shutdown()
 
 	ui := new(cli.MockUi)

--- a/cmd/serf/command/keygen_test.go
+++ b/cmd/serf/command/keygen_test.go
@@ -18,7 +18,7 @@ func TestKeygenCommand(t *testing.T) {
 	output := ui.OutputWriter.String()
 	result, err := base64.StdEncoding.DecodeString(output)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if len(result) != 32 {

--- a/cmd/serf/command/leave_test.go
+++ b/cmd/serf/command/leave_test.go
@@ -4,13 +4,21 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/serf/testutil"
 	"github.com/mitchellh/cli"
 )
 
 func TestLeaveCommandRun(t *testing.T) {
-	a1 := testAgent(t)
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	a1 := testAgent(t, ip1)
 	defer a1.Shutdown()
-	rpcAddr, ipc := testIPC(t, a1)
+
+	rpcAddr, ipc := testIPC(t, ip2, a1)
 	defer ipc.Shutdown()
 
 	ui := new(cli.MockUi)

--- a/cmd/serf/command/members_test.go
+++ b/cmd/serf/command/members_test.go
@@ -4,13 +4,21 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/serf/testutil"
 	"github.com/mitchellh/cli"
 )
 
 func TestMembersCommandRun(t *testing.T) {
-	a1 := testAgent(t)
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	a1 := testAgent(t, ip1)
 	defer a1.Shutdown()
-	rpcAddr, ipc := testIPC(t, a1)
+
+	rpcAddr, ipc := testIPC(t, ip2, a1)
 	defer ipc.Shutdown()
 
 	ui := new(cli.MockUi)
@@ -28,9 +36,16 @@ func TestMembersCommandRun(t *testing.T) {
 }
 
 func TestMembersCommandRun_statusFilter(t *testing.T) {
-	a1 := testAgent(t)
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	a1 := testAgent(t, ip1)
 	defer a1.Shutdown()
-	rpcAddr, ipc := testIPC(t, a1)
+
+	rpcAddr, ipc := testIPC(t, ip2, a1)
 	defer ipc.Shutdown()
 
 	ui := new(cli.MockUi)
@@ -51,9 +66,16 @@ func TestMembersCommandRun_statusFilter(t *testing.T) {
 }
 
 func TestMembersCommandRun_statusFilter_failed(t *testing.T) {
-	a1 := testAgent(t)
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	a1 := testAgent(t, ip1)
 	defer a1.Shutdown()
-	rpcAddr, ipc := testIPC(t, a1)
+
+	rpcAddr, ipc := testIPC(t, ip2, a1)
 	defer ipc.Shutdown()
 
 	ui := new(cli.MockUi)
@@ -74,9 +96,16 @@ func TestMembersCommandRun_statusFilter_failed(t *testing.T) {
 }
 
 func TestMembersCommandRun_roleFilter(t *testing.T) {
-	a1 := testAgent(t)
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	a1 := testAgent(t, ip1)
 	defer a1.Shutdown()
-	rpcAddr, ipc := testIPC(t, a1)
+
+	rpcAddr, ipc := testIPC(t, ip2, a1)
 	defer ipc.Shutdown()
 
 	ui := new(cli.MockUi)
@@ -97,9 +126,16 @@ func TestMembersCommandRun_roleFilter(t *testing.T) {
 }
 
 func TestMembersCommandRun_roleFilter_failed(t *testing.T) {
-	a1 := testAgent(t)
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	a1 := testAgent(t, ip1)
 	defer a1.Shutdown()
-	rpcAddr, ipc := testIPC(t, a1)
+
+	rpcAddr, ipc := testIPC(t, ip2, a1)
 	defer ipc.Shutdown()
 
 	ui := new(cli.MockUi)
@@ -120,9 +156,16 @@ func TestMembersCommandRun_roleFilter_failed(t *testing.T) {
 }
 
 func TestMembersCommandRun_tagFilter(t *testing.T) {
-	a1 := testAgent(t)
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	a1 := testAgent(t, ip1)
 	defer a1.Shutdown()
-	rpcAddr, ipc := testIPC(t, a1)
+
+	rpcAddr, ipc := testIPC(t, ip2, a1)
 	defer ipc.Shutdown()
 
 	ui := new(cli.MockUi)
@@ -143,9 +186,16 @@ func TestMembersCommandRun_tagFilter(t *testing.T) {
 }
 
 func TestMembersCommandRun_tagFilter_failed(t *testing.T) {
-	a1 := testAgent(t)
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	a1 := testAgent(t, ip1)
 	defer a1.Shutdown()
-	rpcAddr, ipc := testIPC(t, a1)
+
+	rpcAddr, ipc := testIPC(t, ip2, a1)
 	defer ipc.Shutdown()
 
 	ui := new(cli.MockUi)
@@ -165,9 +215,16 @@ func TestMembersCommandRun_tagFilter_failed(t *testing.T) {
 	}
 }
 func TestMembersCommandRun_mutliTagFilter(t *testing.T) {
-	a1 := testAgent(t)
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	a1 := testAgent(t, ip1)
 	defer a1.Shutdown()
-	rpcAddr, ipc := testIPC(t, a1)
+
+	rpcAddr, ipc := testIPC(t, ip2, a1)
 	defer ipc.Shutdown()
 
 	ui := new(cli.MockUi)
@@ -189,9 +246,16 @@ func TestMembersCommandRun_mutliTagFilter(t *testing.T) {
 }
 
 func TestMembersCommandRun_multiTagFilter_failed(t *testing.T) {
-	a1 := testAgent(t)
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	a1 := testAgent(t, ip1)
 	defer a1.Shutdown()
-	rpcAddr, ipc := testIPC(t, a1)
+
+	rpcAddr, ipc := testIPC(t, ip2, a1)
 	defer ipc.Shutdown()
 
 	ui := new(cli.MockUi)

--- a/cmd/serf/command/query_test.go
+++ b/cmd/serf/command/query_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/serf/testutil"
 	"github.com/mitchellh/cli"
 )
 
@@ -39,9 +40,16 @@ func TestQueryCommandRun_tooMany(t *testing.T) {
 }
 
 func TestQueryCommandRun(t *testing.T) {
-	a1 := testAgent(t)
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	a1 := testAgent(t, ip1)
 	defer a1.Shutdown()
-	rpcAddr, ipc := testIPC(t, a1)
+
+	rpcAddr, ipc := testIPC(t, ip2, a1)
 	defer ipc.Shutdown()
 
 	ui := new(cli.MockUi)
@@ -59,9 +67,16 @@ func TestQueryCommandRun(t *testing.T) {
 }
 
 func TestQueryCommandRun_tagFilter(t *testing.T) {
-	a1 := testAgent(t)
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	a1 := testAgent(t, ip1)
 	defer a1.Shutdown()
-	rpcAddr, ipc := testIPC(t, a1)
+
+	rpcAddr, ipc := testIPC(t, ip2, a1)
 	defer ipc.Shutdown()
 
 	ui := new(cli.MockUi)
@@ -83,9 +98,16 @@ func TestQueryCommandRun_tagFilter(t *testing.T) {
 }
 
 func TestQueryCommandRun_tagFilter_failed(t *testing.T) {
-	a1 := testAgent(t)
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	a1 := testAgent(t, ip1)
 	defer a1.Shutdown()
-	rpcAddr, ipc := testIPC(t, a1)
+
+	rpcAddr, ipc := testIPC(t, ip2, a1)
 	defer ipc.Shutdown()
 
 	ui := new(cli.MockUi)
@@ -107,9 +129,16 @@ func TestQueryCommandRun_tagFilter_failed(t *testing.T) {
 }
 
 func TestQueryCommandRun_nodeFilter(t *testing.T) {
-	a1 := testAgent(t)
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	a1 := testAgent(t, ip1)
 	defer a1.Shutdown()
-	rpcAddr, ipc := testIPC(t, a1)
+
+	rpcAddr, ipc := testIPC(t, ip2, a1)
 	defer ipc.Shutdown()
 
 	ui := new(cli.MockUi)
@@ -131,9 +160,16 @@ func TestQueryCommandRun_nodeFilter(t *testing.T) {
 }
 
 func TestQueryCommandRun_nodeFilter_failed(t *testing.T) {
-	a1 := testAgent(t)
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	a1 := testAgent(t, ip1)
 	defer a1.Shutdown()
-	rpcAddr, ipc := testIPC(t, a1)
+
+	rpcAddr, ipc := testIPC(t, ip2, a1)
 	defer ipc.Shutdown()
 
 	ui := new(cli.MockUi)
@@ -160,9 +196,16 @@ func TestQueryCommandRun_formatJSON(t *testing.T) {
 		Responses map[string]string
 	}
 
-	a1 := testAgent(t)
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	a1 := testAgent(t, ip1)
 	defer a1.Shutdown()
-	rpcAddr, ipc := testIPC(t, a1)
+
+	rpcAddr, ipc := testIPC(t, ip2, a1)
 	defer ipc.Shutdown()
 
 	ui := new(cli.MockUi)

--- a/cmd/serf/command/reachability_test.go
+++ b/cmd/serf/command/reachability_test.go
@@ -4,13 +4,21 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/serf/testutil"
 	"github.com/mitchellh/cli"
 )
 
 func TestReachabilityCommand_Run(t *testing.T) {
-	a1 := testAgent(t)
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	a1 := testAgent(t, ip1)
 	defer a1.Shutdown()
-	rpcAddr, ipc := testIPC(t, a1)
+
+	rpcAddr, ipc := testIPC(t, ip2, a1)
 	defer ipc.Shutdown()
 
 	ui := new(cli.MockUi)

--- a/cmd/serf/command/rtt_test.go
+++ b/cmd/serf/command/rtt_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/serf/testutil"
 	"github.com/mitchellh/cli"
 )
 
@@ -13,9 +14,16 @@ func TestRTTCommand_Implements(t *testing.T) {
 }
 
 func TestRTTCommand_Run_BadArgs(t *testing.T) {
-	a1 := testAgent(t)
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	a1 := testAgent(t, ip1)
 	defer a1.Shutdown()
-	_, ipc := testIPC(t, a1)
+
+	_, ipc := testIPC(t, ip2, a1)
 	defer ipc.Shutdown()
 
 	ui := new(cli.MockUi)
@@ -28,9 +36,16 @@ func TestRTTCommand_Run_BadArgs(t *testing.T) {
 }
 
 func TestRTTCommand_Run(t *testing.T) {
-	a1 := testAgent(t)
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	a1 := testAgent(t, ip1)
 	defer a1.Shutdown()
-	rpcAddr, ipc := testIPC(t, a1)
+
+	rpcAddr, ipc := testIPC(t, ip2, a1)
 	defer ipc.Shutdown()
 
 	coord, ok := a1.Serf().GetCachedCoordinate(a1.SerfConfig().NodeName)

--- a/cmd/serf/command/tags_test.go
+++ b/cmd/serf/command/tags_test.go
@@ -5,13 +5,21 @@ import (
 	"testing"
 
 	"github.com/hashicorp/serf/client"
+	"github.com/hashicorp/serf/testutil"
 	"github.com/mitchellh/cli"
 )
 
 func TestTagsCommandRun(t *testing.T) {
-	a1 := testAgent(t)
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	a1 := testAgent(t, ip1)
 	defer a1.Shutdown()
-	rpcAddr, ipc := testIPC(t, a1)
+
+	rpcAddr, ipc := testIPC(t, ip2, a1)
 	defer ipc.Shutdown()
 
 	ui := new(cli.MockUi)
@@ -34,12 +42,12 @@ func TestTagsCommandRun(t *testing.T) {
 
 	rpcClient, err := client.NewRPCClient(rpcAddr)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	mem, err := rpcClient.Members()
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if len(mem) != 1 {

--- a/cmd/serf/command/util_test.go
+++ b/cmd/serf/command/util_test.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"fmt"
 	"io"
 	"math/rand"
 	"net"
@@ -19,52 +18,38 @@ func init() {
 	rand.Seed(time.Now().UnixNano())
 }
 
-func testAgent(t *testing.T) *agent.Agent {
+func testAgent(t *testing.T, ip net.IP) *agent.Agent {
 	agentConfig := agent.DefaultConfig()
 	serfConfig := serf.DefaultConfig()
-	return testAgentWithConfig(t, agentConfig, serfConfig)
+	return testAgentWithConfig(t, ip, agentConfig, serfConfig)
 }
 
-func testAgentWithConfig(t *testing.T, agentConfig *agent.Config,
-	serfConfig *serf.Config) *agent.Agent {
-
-	serfConfig.MemberlistConfig.BindAddr = testutil.GetBindAddr().String()
+func testAgentWithConfig(t *testing.T, ip net.IP, agentConfig *agent.Config, serfConfig *serf.Config) *agent.Agent {
+	serfConfig.MemberlistConfig.BindAddr = ip.String()
 	serfConfig.MemberlistConfig.ProbeInterval = 50 * time.Millisecond
 	serfConfig.MemberlistConfig.ProbeTimeout = 25 * time.Millisecond
 	serfConfig.MemberlistConfig.SuspicionMult = 1
 	serfConfig.NodeName = serfConfig.MemberlistConfig.BindAddr
 	serfConfig.Tags = map[string]string{"role": "test", "tag1": "foo", "tag2": "bar"}
 
-	agent, err := agent.Create(agentConfig, serfConfig, nil)
+	agent, err := agent.Create(agentConfig, serfConfig, testutil.TestWriter(t))
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if err := agent.Start(); err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	return agent
 }
 
-func getRPCAddr() string {
-	for i := 0; i < 500; i++ {
-		l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", rand.Int31n(25000)+1024))
-		if err == nil {
-			l.Close()
-			return l.Addr().String()
-		}
-	}
-
-	panic("no listener")
-}
-
-func testIPC(t *testing.T, a *agent.Agent) (string, *agent.AgentIPC) {
-	rpcAddr := getRPCAddr()
+func testIPC(t *testing.T, ip net.IP, a *agent.Agent) (string, *agent.AgentIPC) {
+	rpcAddr := ip.String() + ":11111"
 
 	l, err := net.Listen("tcp", rpcAddr)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	lw := agent.NewLogWriter(512)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/hashicorp/serf
 
+go 1.12
+
 require (
 	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
 	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da

--- a/serf/internal_query_test.go
+++ b/serf/internal_query_test.go
@@ -92,7 +92,7 @@ func TestSerfQueries_Conflict_SameName(t *testing.T) {
 func TestSerfQueries_estimateMaxKeysInListKeyResponseFactor(t *testing.T) {
 	q := Query{id: 0, serf: &Serf{config: &Config{NodeName: "", QueryResponseSizeLimit: DefaultConfig().QueryResponseSizeLimit * 10}}}
 	resp := nodeKeyResponse{Keys: []string{}}
-	for i := 0; i <= q.serf.config.QueryResponseSizeLimit; i++ {
+	for i := 0; i <= q.serf.config.QueryResponseSizeLimit/minEncodedKeyLength; i++ {
 		resp.Keys = append(resp.Keys, "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=")
 	}
 	found := 0

--- a/serf/keymanager_test.go
+++ b/serf/keymanager_test.go
@@ -3,6 +3,7 @@ package serf
 import (
 	"bytes"
 	"encoding/base64"
+	"net"
 	"testing"
 
 	"github.com/hashicorp/memberlist"
@@ -28,8 +29,8 @@ func testKeyring() (*memberlist.Keyring, error) {
 	return memberlist.NewKeyring(keysDecoded, keysDecoded[0])
 }
 
-func testKeyringSerf() (*Serf, error) {
-	config := testConfig()
+func testKeyringSerf(t *testing.T, ip net.IP) (*Serf, error) {
+	config := testConfig(t, ip)
 
 	keyring, err := testKeyring()
 	if err != nil {
@@ -55,33 +56,41 @@ func keyExistsInRing(kr *memberlist.Keyring, key []byte) bool {
 }
 
 func TestSerf_InstallKey(t *testing.T) {
-	s1, err := testKeyringSerf()
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	s1, err := testKeyringSerf(t, ip1)
 	if err != nil {
-		t.Fatalf("%s", err)
+		t.Fatalf("err: %v", err)
 	}
 	defer s1.Shutdown()
 
-	s2, err := testKeyringSerf()
+	s2, err := testKeyringSerf(t, ip2)
 	if err != nil {
-		t.Fatalf("%s", err)
+		t.Fatalf("err: %v", err)
 	}
 	defer s2.Shutdown()
 
 	primaryKey := s1.config.MemberlistConfig.Keyring.GetPrimaryKey()
 
+	waitUntilNumNodes(t, 1, s1, s2)
+
 	// Join s1 and s2
 	_, err = s1.Join([]string{s2.config.MemberlistConfig.BindAddr}, false)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
-	testutil.Yield()
+	waitUntilNumNodes(t, 2, s1, s2)
 
 	// Begin tests
 	newKey := "HvY8ubRZMgafUOWvrOadwOckVa1wN3QWAo46FVKbVN8="
 	newKeyBytes, err := base64.StdEncoding.DecodeString(newKey)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	manager := s1.KeyManager()
@@ -90,7 +99,7 @@ func TestSerf_InstallKey(t *testing.T) {
 	// need for a yield.
 	_, err = manager.InstallKey(newKey)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	// Key installation did not affect the current primary key
@@ -113,31 +122,39 @@ func TestSerf_InstallKey(t *testing.T) {
 }
 
 func TestSerf_UseKey(t *testing.T) {
-	s1, err := testKeyringSerf()
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	s1, err := testKeyringSerf(t, ip1)
 	if err != nil {
-		t.Fatalf("%s", err)
+		t.Fatalf("err: %v", err)
 	}
 	defer s1.Shutdown()
 
-	s2, err := testKeyringSerf()
+	s2, err := testKeyringSerf(t, ip2)
 	if err != nil {
-		t.Fatalf("%s", err)
+		t.Fatalf("err: %v", err)
 	}
 	defer s2.Shutdown()
+
+	waitUntilNumNodes(t, 1, s1, s2)
 
 	// Join s1 and s2
 	_, err = s1.Join([]string{s2.config.MemberlistConfig.BindAddr}, false)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
-	testutil.Yield()
+	waitUntilNumNodes(t, 2, s1, s2)
 
 	// Begin tests
 	useKey := "HvY8ubRZMgafUOWvrOadwOckVa1wN3QWAo46FVKbVN8="
 	useKeyBytes, err := base64.StdEncoding.DecodeString(useKey)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	manager := s1.KeyManager()
@@ -145,7 +162,7 @@ func TestSerf_UseKey(t *testing.T) {
 	// Change the primary encryption key
 	_, err = manager.UseKey(useKey)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	// First make sure that the primary key is what we expect it to be
@@ -165,31 +182,39 @@ func TestSerf_UseKey(t *testing.T) {
 }
 
 func TestSerf_RemoveKey(t *testing.T) {
-	s1, err := testKeyringSerf()
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	s1, err := testKeyringSerf(t, ip1)
 	if err != nil {
-		t.Fatalf("%s", err)
+		t.Fatalf("err: %v", err)
 	}
 	defer s1.Shutdown()
 
-	s2, err := testKeyringSerf()
+	s2, err := testKeyringSerf(t, ip2)
 	if err != nil {
-		t.Fatalf("%s", err)
+		t.Fatalf("err: %v", err)
 	}
 	defer s2.Shutdown()
+
+	waitUntilNumNodes(t, 1, s1, s2)
 
 	// Join s1 and s2
 	_, err = s1.Join([]string{s2.config.MemberlistConfig.BindAddr}, false)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
-	testutil.Yield()
+	waitUntilNumNodes(t, 2, s1, s2)
 
 	// Begin tests
 	removeKey := "T9jncgl9mbLus+baTTa7q7nPSUrXwbDi2dhbtqir37s="
 	removeKeyBytes, err := base64.StdEncoding.DecodeString(removeKey)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	manager := s1.KeyManager()
@@ -197,7 +222,7 @@ func TestSerf_RemoveKey(t *testing.T) {
 	// Remove a key from the ring
 	_, err = manager.RemoveKey(removeKey)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	// Key was successfully removed from all members
@@ -211,15 +236,21 @@ func TestSerf_RemoveKey(t *testing.T) {
 }
 
 func TestSerf_ListKeys(t *testing.T) {
-	s1, err := testKeyringSerf()
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	s1, err := testKeyringSerf(t, ip1)
 	if err != nil {
-		t.Fatalf("%s", err)
+		t.Fatalf("err: %v", err)
 	}
 	defer s1.Shutdown()
 
-	s2, err := testKeyringSerf()
+	s2, err := testKeyringSerf(t, ip2)
 	if err != nil {
-		t.Fatalf("%s", err)
+		t.Fatalf("err: %v", err)
 	}
 	defer s2.Shutdown()
 
@@ -231,21 +262,24 @@ func TestSerf_ListKeys(t *testing.T) {
 	extraKey := "5K9OtfP7efFrNKe5WCQvXvnaXJ5cWP0SvXiwe0kkjM4="
 	extraKeyBytes, err := base64.StdEncoding.DecodeString(extraKey)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
+
 	s2.config.MemberlistConfig.Keyring.AddKey(extraKeyBytes)
+
+	waitUntilNumNodes(t, 1, s1, s2)
 
 	// Join s1 and s2
 	_, err = s1.Join([]string{s2.config.MemberlistConfig.BindAddr}, false)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
-	testutil.Yield()
+	waitUntilNumNodes(t, 2, s1, s2)
 
 	resp, err := manager.ListKeys()
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	// Found all keys in the list

--- a/serf/messages_test.go
+++ b/serf/messages_test.go
@@ -22,7 +22,7 @@ func TestEncodeMessage(t *testing.T) {
 	in := &messageLeave{Node: "foo"}
 	raw, err := encodeMessage(messageLeaveType, in)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if raw[0] != byte(messageLeaveType) {
@@ -31,7 +31,7 @@ func TestEncodeMessage(t *testing.T) {
 
 	var out messageLeave
 	if err := decodeMessage(raw[1:], &out); err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if !reflect.DeepEqual(in, &out) {
@@ -44,7 +44,7 @@ func TestEncodeRelayMessage(t *testing.T) {
 	addr := net.UDPAddr{IP: net.IP{127, 0, 0, 1}, Port: 1234}
 	raw, err := encodeRelayMessage(messageLeaveType, addr, in)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if raw[0] != byte(messageRelayType) {
@@ -72,7 +72,7 @@ func TestEncodeRelayMessage(t *testing.T) {
 
 	var message messageLeave
 	if err := decoder.Decode(&message); err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if !reflect.DeepEqual(in, &message) {
@@ -85,7 +85,7 @@ func TestEncodeFilter(t *testing.T) {
 
 	raw, err := encodeFilter(filterNodeType, nodes)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if raw[0] != byte(filterNodeType) {
@@ -94,7 +94,7 @@ func TestEncodeFilter(t *testing.T) {
 
 	var out []string
 	if err := decodeMessage(raw[1:], &out); err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if !reflect.DeepEqual(nodes, out) {

--- a/serf/query_test.go
+++ b/serf/query_test.go
@@ -5,13 +5,18 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/serf/testutil"
 )
 
 func TestDefaultQuery(t *testing.T) {
-	s1Config := testConfig()
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	s1Config := testConfig(t, ip1)
 	s1, err := Create(s1Config)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 	defer s1.Shutdown()
 
@@ -46,7 +51,7 @@ func TestQueryParams_EncodeFilters(t *testing.T) {
 
 	filters, err := q.encodeFilters()
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 	if len(filters) != 3 {
 		t.Fatalf("bad: %v", filters)
@@ -69,7 +74,10 @@ func TestQueryParams_EncodeFilters(t *testing.T) {
 }
 
 func TestSerf_ShouldProcess(t *testing.T) {
-	s1Config := testConfig()
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	s1Config := testConfig(t, ip1)
 	s1Config.NodeName = "zip"
 	s1Config.Tags = map[string]string{
 		"role":       "webserver",
@@ -77,7 +85,7 @@ func TestSerf_ShouldProcess(t *testing.T) {
 	}
 	s1, err := Create(s1Config)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 	defer s1.Shutdown()
 
@@ -91,7 +99,7 @@ func TestSerf_ShouldProcess(t *testing.T) {
 	}
 	filters, err := q.encodeFilters()
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if !s1.shouldProcessQuery(filters) {
@@ -104,7 +112,7 @@ func TestSerf_ShouldProcess(t *testing.T) {
 	}
 	filters, err = q.encodeFilters()
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 	if s1.shouldProcessQuery(filters) {
 		t.Fatalf("expected false")
@@ -118,7 +126,7 @@ func TestSerf_ShouldProcess(t *testing.T) {
 	}
 	filters, err = q.encodeFilters()
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 	if s1.shouldProcessQuery(filters) {
 		t.Fatalf("expected false")
@@ -132,7 +140,7 @@ func TestSerf_ShouldProcess(t *testing.T) {
 	}
 	filters, err = q.encodeFilters()
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("err: %v", err)
 	}
 	if s1.shouldProcessQuery(filters) {
 		t.Fatalf("expected false")

--- a/testutil/addr.go
+++ b/testutil/addr.go
@@ -1,23 +1,76 @@
 package testutil
 
 import (
+	"container/list"
+	"fmt"
 	"net"
+	"os"
 	"sync"
+	"time"
 )
 
-var bindLock sync.Mutex
-var bindNum byte = 10
+var (
+	bindLock     sync.Mutex
+	freeIPs      *list.List
+	condNotEmpty *sync.Cond
+)
 
-// Returns an unused address for binding to for tests.
-func GetBindAddr() net.IP {
+const bindLockPort = 10101
+
+func init() {
+	freeIPs = list.New()
+	condNotEmpty = sync.NewCond(&bindLock)
+	for octet := byte(10); octet < 255; octet++ {
+		result := net.IPv4(127, 0, 0, octet)
+		freeIPs.PushBack(result)
+	}
+}
+
+func returnIP(ip net.IP) {
+	bindLock.Lock()
+	defer bindLock.Unlock()
+	freeIPs.PushBack(ip)
+	condNotEmpty.Broadcast()
+}
+
+func getBindAddr() net.IP {
 	bindLock.Lock()
 	defer bindLock.Unlock()
 
-	result := net.IPv4(127, 0, 0, bindNum)
-	bindNum++
-	if bindNum == 0 {
-		bindNum = 10
+	for freeIPs.Len() == 0 {
+		condNotEmpty.Wait()
 	}
 
+	elem := freeIPs.Front()
+	freeIPs.Remove(elem)
+	result := elem.Value.(net.IP)
+
 	return result
+}
+
+func TakeIP() (ip net.IP, returnFn func()) {
+	for attempts := 0; ; attempts++ {
+		ip = getBindAddr()
+
+		addr := &net.TCPAddr{IP: ip, Port: bindLockPort}
+
+		ln, err := net.ListenTCP("tcp4", addr)
+		if err != nil {
+			returnIP(ip)
+			continue
+		}
+
+		if attempts > 3 {
+			logf("took %s after %d attempts", ip, attempts)
+		}
+		return ip, func() {
+			ln.Close()
+			time.Sleep(50 * time.Millisecond) // let the kernel cool down
+			returnIP(ip)
+		}
+	}
+}
+
+func logf(format string, a ...interface{}) {
+	fmt.Fprintf(os.Stdout, "testutil: "+format+"\n", a...)
 }

--- a/testutil/testlog.go
+++ b/testutil/testlog.go
@@ -1,0 +1,30 @@
+package testutil
+
+import (
+	"io"
+	"log"
+	"strings"
+	"testing"
+)
+
+func TestLogger(t testing.TB) *log.Logger {
+	return log.New(&testWriter{t}, "test: ", log.LstdFlags)
+}
+
+func TestLoggerWithName(t testing.TB, name string) *log.Logger {
+	return log.New(&testWriter{t}, "test["+name+"]: ", log.LstdFlags)
+}
+
+func TestWriter(t testing.TB) io.Writer {
+	return &testWriter{t}
+}
+
+type testWriter struct {
+	t testing.TB
+}
+
+func (tw *testWriter) Write(p []byte) (n int, err error) {
+	tw.t.Helper()
+	tw.t.Log(strings.TrimSpace(string(p)))
+	return len(p), nil
+}


### PR DESCRIPTION
Also:
- sync some makefile targets back from consul
- reroute test log output through testing.T.Logf
- include memberlist logs with serf logs