### PR TITLE
Avoid issue where two unique leave events for the same node could lead to infinite rebroadcast storms

### DIFF
--- a/serf/config.go
+++ b/serf/config.go
@@ -247,10 +247,12 @@ type Config struct {
 	// It's optimal to be relatively small, since it's going to be gossiped through the cluster.
 	UserEventSizeLimit int
 
-	// MessageDropper is a callback used for selectively ignoring inbound
+	// messageDropper is a callback used for selectively ignoring inbound
 	// gossip messages. This should only be used in unit tests needing careful
 	// control over sequencing of gossip arrival
-	MessageDropper func(typ messageType) bool
+	//
+	// WARNING: this should ONLY be used in tests
+	messageDropper func(typ messageType) bool
 }
 
 // Init allocates the subdata structures
@@ -258,8 +260,8 @@ func (c *Config) Init() {
 	if c.Tags == nil {
 		c.Tags = make(map[string]string)
 	}
-	if c.MessageDropper == nil {
-		c.MessageDropper = func(typ messageType) bool {
+	if c.messageDropper == nil {
+		c.messageDropper = func(typ messageType) bool {
 			return false
 		}
 	}

--- a/serf/config.go
+++ b/serf/config.go
@@ -246,12 +246,22 @@ type Config struct {
 	// UserEventSizeLimit is maximum byte size limit of user event `name` + `payload` in bytes.
 	// It's optimal to be relatively small, since it's going to be gossiped through the cluster.
 	UserEventSizeLimit int
+
+	// MessageDropper is a callback used for selectively ignoring inbound
+	// gossip messages. This should only be used in unit tests needing careful
+	// control over sequencing of gossip arrival
+	MessageDropper func(typ messageType) bool
 }
 
 // Init allocates the subdata structures
 func (c *Config) Init() {
 	if c.Tags == nil {
 		c.Tags = make(map[string]string)
+	}
+	if c.MessageDropper == nil {
+		c.MessageDropper = func(typ messageType) bool {
+			return false
+		}
 	}
 }
 

--- a/serf/delegate.go
+++ b/serf/delegate.go
@@ -36,7 +36,7 @@ func (d *delegate) NotifyMsg(buf []byte) {
 	rebroadcastQueue := d.serf.broadcasts
 	t := messageType(buf[0])
 
-	if d.serf.config.MessageDropper(t) {
+	if d.serf.config.messageDropper(t) {
 		return
 	}
 
@@ -218,7 +218,7 @@ func (d *delegate) MergeRemoteState(buf []byte, isJoin bool) {
 		return
 	}
 
-	if d.serf.config.MessageDropper(messagePushPullType) {
+	if d.serf.config.messageDropper(messagePushPullType) {
 		return
 	}
 

--- a/serf/delegate.go
+++ b/serf/delegate.go
@@ -35,6 +35,11 @@ func (d *delegate) NotifyMsg(buf []byte) {
 	rebroadcast := false
 	rebroadcastQueue := d.serf.broadcasts
 	t := messageType(buf[0])
+
+	if d.serf.config.MessageDropper(t) {
+		return
+	}
+
 	switch t {
 	case messageLeaveType:
 		var leave messageLeave
@@ -210,6 +215,10 @@ func (d *delegate) MergeRemoteState(buf []byte, isJoin bool) {
 	// Check the message type
 	if messageType(buf[0]) != messagePushPullType {
 		d.serf.logger.Printf("[ERR] serf: Remote state has bad type prefix: %v", buf[0])
+		return
+	}
+
+	if d.serf.config.MessageDropper(messagePushPullType) {
 		return
 	}
 

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -907,7 +907,7 @@ func (s *Serf) handleNodeJoin(n *memberlist.Node) {
 	s.memberLock.Lock()
 	defer s.memberLock.Unlock()
 
-	if s.config.MessageDropper(messageJoinType) {
+	if s.config.messageDropper(messageJoinType) {
 		return
 	}
 
@@ -1110,7 +1110,6 @@ func (s *Serf) handleNodeLeaveIntent(leaveMsg *messageLeave) bool {
 	switch member.Status {
 	case StatusAlive:
 		member.Status = StatusLeaving
-		member.statusLTime = leaveMsg.LTime
 
 		if leaveMsg.Prune {
 			s.handlePrune(member)
@@ -1118,7 +1117,6 @@ func (s *Serf) handleNodeLeaveIntent(leaveMsg *messageLeave) bool {
 		return true
 	case StatusFailed:
 		member.Status = StatusLeft
-		member.statusLTime = leaveMsg.LTime
 
 		// Remove from the failed list and add to the left list. We add
 		// to the left list so that when we do a sync, other nodes will

--- a/serf/serf_test.go
+++ b/serf/serf_test.go
@@ -10,8 +10,10 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -274,6 +276,156 @@ func TestSerf_eventsLeave(t *testing.T) {
 	// a leave event in s1 about the leave.
 	testEvents(t, eventCh, s2Config.NodeName,
 		[]EventType{EventMemberJoin, EventMemberLeave})
+}
+
+func TestSerf_eventsLeave_avoidInfiniteLeaveRebroadcast(t *testing.T) {
+	// This test is a variation of the normal leave test that is crafted
+	// specifically to handle a situation where two unique leave events for the
+	// same node reach two other nodes in the wrong order which causes them to
+	// infinitely rebroadcast the leave event without updating their own
+	// lamport clock for that node.
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	ip3, returnFn3 := testutil.TakeIP()
+	defer returnFn3()
+
+	ip4, returnFn4 := testutil.TakeIP()
+	defer returnFn4()
+
+	testConfigLocal := func(t *testing.T, ip net.IP) *Config {
+		conf := testConfig(t, ip)
+		// Make the reap interval longer in this test
+		// so that the leave does not also cause a reap
+		conf.ReapInterval = 30 * time.Second
+		return conf
+	}
+
+	// Create the s1 config with an event channel so we can listen
+	eventCh := make(chan Event, 4)
+	s1Config := testConfigLocal(t, ip1)
+	s1Config.EventCh = eventCh
+
+	s2Config := testConfigLocal(t, ip2)
+	s2Config.RejoinAfterLeave = true
+	s2Addr := s2Config.MemberlistConfig.BindAddr
+	s2Name := s2Config.NodeName
+
+	s3Config := testConfigLocal(t, ip3)
+	// Allow s3 to drop joins in the future.
+	var s3DropJoins uint32
+	s3Config.MessageDropper = func(t messageType) bool {
+		switch t {
+		case messageJoinType, messagePushPullType:
+			return atomic.LoadUint32(&s3DropJoins) == 1
+		default:
+			return false
+		}
+	}
+
+	s4Config := testConfigLocal(t, ip4)
+	// Allow s4 to drop joins in the future.
+	var s4DropJoins uint32
+	s4Config.MessageDropper = func(t messageType) bool {
+		switch t {
+		case messageJoinType, messagePushPullType:
+			return atomic.LoadUint32(&s4DropJoins) == 1
+		default:
+			return false
+		}
+	}
+
+	s1, err := Create(s1Config)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer s1.Shutdown()
+
+	s2, err := Create(s2Config)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer s2.Shutdown()
+
+	s3, err := Create(s3Config)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer s3.Shutdown()
+
+	s4, err := Create(s4Config)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer s4.Shutdown()
+
+	waitUntilNumNodes(t, 1, s1, s2)
+
+	_, err = s1.Join([]string{s2Config.NodeName + "/" + s2Config.MemberlistConfig.BindAddr}, false)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	_, err = s3.Join([]string{s2Config.NodeName + "/" + s2Config.MemberlistConfig.BindAddr}, false)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	_, err = s4.Join([]string{s2Config.NodeName + "/" + s2Config.MemberlistConfig.BindAddr}, false)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// S2 leaves gracefully
+	if err := s2.Leave(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if err := s2.Shutdown(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Make s3 and s4 drop inbound join messages and push-pulls for a bit so it won't see
+	// s2 rejoin
+	atomic.StoreUint32(&s3DropJoins, 1)
+	atomic.StoreUint32(&s4DropJoins, 1)
+
+	// Bring back s2 by mimicking its name and address
+	s2Config = testConfigLocal(t, ip2)
+	s2Config.RejoinAfterLeave = true
+	s2Config.MemberlistConfig.BindAddr = s2Addr
+	s2Config.NodeName = s2Name
+	s2, err = Create(s2Config)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer s2.Shutdown()
+
+	_, err = s2.Join([]string{s1Config.NodeName + "/" + s1Config.MemberlistConfig.BindAddr}, false)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	waitUntilNumNodes(t, 4, s1, s2, s3, s4)
+
+	// Now leave a second time but before s3 saw the rejoin (due to the gate)
+	if err := s2.Leave(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	waitUntilIntentQueueLen(t, 0, s1, s3, s4)
+
+	retry.Run(t, func(r *retry.R) {
+		testMemberStatus(r, s1.Members(), s2Config.NodeName, StatusLeft)
+		testMemberStatus(r, s3.Members(), s2Config.NodeName, StatusLeft)
+		testMemberStatus(r, s4.Members(), s2Config.NodeName, StatusLeft)
+	})
+
+	// Now that s2 has left, we check the events to make sure we got
+	// a leave event in s1 about the leave.
+	testEvents(t, eventCh, s2Config.NodeName,
+		[]EventType{EventMemberJoin, EventMemberLeave,
+			EventMemberJoin, EventMemberLeave})
 }
 
 func TestSerf_RemoveFailed_eventsLeave(t *testing.T) {
@@ -2805,6 +2957,24 @@ func waitUntilNumNodes(t *testing.T, desiredNodes int, serfs ...*Serf) {
 		for i, s := range serfs {
 			if n := s.NumNodes(); desiredNodes != n {
 				r.Fatalf("s%d got %d expected %d", (i + 1), n, desiredNodes)
+			}
+		}
+	})
+}
+
+func waitUntilIntentQueueLen(t *testing.T, desiredLen int, serfs ...*Serf) {
+	t.Helper()
+	retry.Run(t, func(r *retry.R) {
+		t.Helper()
+		for i, s := range serfs {
+			stats := s.Stats()
+			iq, err := strconv.Atoi(stats["intent_queue"])
+			if err != nil {
+				r.Fatalf("err: %v", err)
+			}
+
+			if desiredLen != iq {
+				r.Fatalf("s%d got %d expected %d", (i + 1), iq, desiredLen)
 			}
 		}
 	})

--- a/serf/serf_test.go
+++ b/serf/serf_test.go
@@ -317,7 +317,7 @@ func TestSerf_eventsLeave_avoidInfiniteLeaveRebroadcast(t *testing.T) {
 	s3Config := testConfigLocal(t, ip3)
 	// Allow s3 to drop joins in the future.
 	var s3DropJoins uint32
-	s3Config.MessageDropper = func(t messageType) bool {
+	s3Config.messageDropper = func(t messageType) bool {
 		switch t {
 		case messageJoinType, messagePushPullType:
 			return atomic.LoadUint32(&s3DropJoins) == 1
@@ -329,7 +329,7 @@ func TestSerf_eventsLeave_avoidInfiniteLeaveRebroadcast(t *testing.T) {
 	s4Config := testConfigLocal(t, ip4)
 	// Allow s4 to drop joins in the future.
 	var s4DropJoins uint32
-	s4Config.MessageDropper = func(t messageType) bool {
+	s4Config.messageDropper = func(t messageType) bool {
 		switch t {
 		case messageJoinType, messagePushPullType:
 			return atomic.LoadUint32(&s4DropJoins) == 1


### PR DESCRIPTION
Fixes this scenario:

When two leave events for the same node (with different ltimes) are
received by two or more additional nodes without any intermediate state
transitions it will lead to them setting up an infinite gossip echo
chamber rebroadcasting the original node's leave.

When in this situation the only way to recover would be to either:

- Bring the node back so it can send out a fresh "alive" message.

- Use force-leave prune to purge the node's existence from the cluster.

There are two known ways to arrive in this situation:

1. Have a node leave the cluster and then from a differnet node initiate
   a force-leave. This is the easiest way to reproduce.

2. Have a node leave, rejoin, and leave again in quick succession. This
   requires winning a lot of races in just the right way to have gossip
   from the first leave still rebroadcasting naturally WHILE the second
   round of leaves is rebroadcasting AND to have those rounds of gossip
   arrive at the target nodes before they see the rebroadcast of the
   intervening REJOIN.

The fix is pretty simple. When we witness a node leave event, before we
rebroadcast we need to update the lamport time associated with that node
so that the ltime check will cause the same event to be processed again
and again.

Fixes https://github.com/hashicorp/consul/issues/7960
Fixes https://github.com/hashicorp/consul/issues/8179