### PR TITLE
[backport on v0.8.5] Avoid issue where two unique leave events for the same node could lead to infinite rebroadcast storms

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/hashicorp/serf
 
+go 1.12
+
 require (
 	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
 	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da
@@ -12,6 +14,6 @@ require (
 	github.com/mitchellh/cli v1.0.0
 	github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee
 	github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f
-	github.com/stretchr/testify v1.3.0 // indirect
+	github.com/stretchr/testify v1.3.0
 	golang.org/x/net v0.0.0-20181201002055-351d144fa1fc // indirect
 )

--- a/serf/config.go
+++ b/serf/config.go
@@ -246,12 +246,24 @@ type Config struct {
 	// UserEventSizeLimit is maximum byte size limit of user event `name` + `payload` in bytes.
 	// It's optimal to be relatively small, since it's going to be gossiped through the cluster.
 	UserEventSizeLimit int
+
+	// messageDropper is a callback used for selectively ignoring inbound
+	// gossip messages. This should only be used in unit tests needing careful
+	// control over sequencing of gossip arrival
+	//
+	// WARNING: this should ONLY be used in tests
+	messageDropper func(typ messageType) bool
 }
 
 // Init allocates the subdata structures
 func (c *Config) Init() {
 	if c.Tags == nil {
 		c.Tags = make(map[string]string)
+	}
+	if c.messageDropper == nil {
+		c.messageDropper = func(typ messageType) bool {
+			return false
+		}
 	}
 }
 

--- a/serf/delegate.go
+++ b/serf/delegate.go
@@ -35,6 +35,11 @@ func (d *delegate) NotifyMsg(buf []byte) {
 	rebroadcast := false
 	rebroadcastQueue := d.serf.broadcasts
 	t := messageType(buf[0])
+
+	if d.serf.config.messageDropper(t) {
+		return
+	}
+
 	switch t {
 	case messageLeaveType:
 		var leave messageLeave
@@ -204,6 +209,10 @@ func (d *delegate) MergeRemoteState(buf []byte, isJoin bool) {
 	// Check the message type
 	if messageType(buf[0]) != messagePushPullType {
 		d.serf.logger.Printf("[ERR] serf: Remote state has bad type prefix: %v", buf[0])
+		return
+	}
+
+	if d.serf.config.messageDropper(messagePushPullType) {
 		return
 	}
 

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -906,6 +906,10 @@ func (s *Serf) handleNodeJoin(n *memberlist.Node) {
 	s.memberLock.Lock()
 	defer s.memberLock.Unlock()
 
+	if s.config.messageDropper(messageJoinType) {
+		return
+	}
+
 	var oldStatus MemberStatus
 	member, ok := s.members[n.Name]
 	if !ok {
@@ -1097,11 +1101,14 @@ func (s *Serf) handleNodeLeaveIntent(leaveMsg *messageLeave) bool {
 		return false
 	}
 
+	// Always set the lamport time so that if we retransmit below it won't echo
+	// around forever!
+	member.statusLTime = leaveMsg.LTime
+
 	// State transition depends on current state
 	switch member.Status {
 	case StatusAlive:
 		member.Status = StatusLeaving
-		member.statusLTime = leaveMsg.LTime
 
 		if leaveMsg.Prune {
 			s.handlePrune(member)
@@ -1109,7 +1116,6 @@ func (s *Serf) handleNodeLeaveIntent(leaveMsg *messageLeave) bool {
 		return true
 	case StatusFailed:
 		member.Status = StatusLeft
-		member.statusLTime = leaveMsg.LTime
 
 		// Remove from the failed list and add to the left list. We add
 		// to the left list so that when we do a sync, other nodes will


### PR DESCRIPTION
Backport of #606 to follow serf v0.8.5