### PR TITLE
Fix getting VERSION from version.go in makefile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,7 +1,7 @@
 SHELL := bash
 
 GOTOOLS := github.com/mitchellh/gox
-VERSION := $(shell awk -F\" '/^const Version/ { print $$2; exit }' cmd/serf/version.go)
+VERSION := $(shell awk -F\" '/Version = "(.*)"/ { print $$2; exit }' version/version.go)
 GITSHA:=$(shell git rev-parse HEAD)
 GITBRANCH:=$(shell git symbolic-ref --short HEAD 2>/dev/null)
 


### PR DESCRIPTION
Currently `make dist` fails because it can't find file `cmd/serf/version.go`:

```
$ make dist
awk: can't open file cmd/serf/version.go
 source line number 1
Please specify a version.
make: *** [dist] Error 1
```