### PR TITLE
add primary key to keylist response

### DIFF
--- a/serf/internal_query.go
+++ b/serf/internal_query.go
@@ -64,6 +64,9 @@ type nodeKeyResponse struct {
 
 	// Keys is used in listing queries to relay a list of installed keys
 	Keys []string
+
+	// PrimaryKey is used in listing queries to relay the primary key
+	PrimaryKey string
 }
 
 // newSerfQueries is used to create a new serfQueries. We return an event
@@ -346,7 +349,7 @@ SEND:
 func (s *serfQueries) handleListKeys(q *Query) {
 	response := nodeKeyResponse{Result: false}
 	keyring := s.serf.config.MemberlistConfig.Keyring
-
+	var primaryKeyBytes []byte
 	if !s.serf.EncryptionEnabled() {
 		response.Message = "Keyring is empty (encryption not enabled)"
 		s.logger.Printf("[ERR] serf: Keyring is empty (encryption not enabled)")
@@ -360,6 +363,9 @@ func (s *serfQueries) handleListKeys(q *Query) {
 		key := base64.StdEncoding.EncodeToString(keyBytes)
 		response.Keys = append(response.Keys, key)
 	}
+	primaryKeyBytes = keyring.GetPrimaryKey()
+	response.PrimaryKey = base64.StdEncoding.EncodeToString(primaryKeyBytes)
+
 	response.Result = true
 
 SEND:

--- a/serf/internal_query_test.go
+++ b/serf/internal_query_test.go
@@ -131,7 +131,7 @@ func TestSerfQueries_keyListResponseWithCorrectSize(t *testing.T) {
 		{expected: 0, hasMsg: false, resp: nodeKeyResponse{}},
 		{expected: 1, hasMsg: false, resp: nodeKeyResponse{Keys: []string{"KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg="}}},
 		// has 50 keys which makes the response bigger than 1024 bytes.
-		{expected: 19, hasMsg: true, resp: nodeKeyResponse{Keys: []string{
+		{expected: 18, hasMsg: true, resp: nodeKeyResponse{Keys: []string{
 			"KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=",
 			"KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=",
 			"KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=", "KfCPZAKdgHUOdb202afZfE8EbdZqj4+ReTbfJUkfKsg=",

--- a/serf/keymanager.go
+++ b/serf/keymanager.go
@@ -80,18 +80,10 @@ func (k *KeyManager) streamKeyResp(resp *KeyResponse, ch <-chan NodeResponse) {
 		// Currently only used for key list queries, this adds keys to a counter
 		// and increments them for each node response which contains them.
 		for _, key := range nodeResponse.Keys {
-			if _, ok := resp.Keys[key]; !ok {
-				resp.Keys[key] = 1
-			} else {
-				resp.Keys[key]++
-			}
+			resp.Keys[key]++
 		}
 
-		if _, ok := resp.PrimaryKeys[nodeResponse.PrimaryKey]; !ok {
-			resp.PrimaryKeys[nodeResponse.PrimaryKey] = 1
-		} else {
-			resp.PrimaryKeys[nodeResponse.PrimaryKey]++
-		}
+		resp.PrimaryKeys[nodeResponse.PrimaryKey]++
 
 	NEXT:
 		// Return early if all nodes have responded. This allows us to avoid

--- a/serf/keymanager.go
+++ b/serf/keymanager.go
@@ -31,6 +31,10 @@ type KeyResponse struct {
 	// Keys is a mapping of the base64-encoded value of the key bytes to the
 	// number of nodes that have the key installed.
 	Keys map[string]int
+
+	// PrimaryKeys is a mapping of the base64-encoded value of the primary
+	// key bytes to the number of nodes that have the key installed.
+	PrimaryKeys map[string]int
 }
 
 // KeyRequestOptions is used to contain optional parameters for a keyring operation
@@ -83,6 +87,12 @@ func (k *KeyManager) streamKeyResp(resp *KeyResponse, ch <-chan NodeResponse) {
 			}
 		}
 
+		if _, ok := resp.PrimaryKeys[nodeResponse.PrimaryKey]; !ok {
+			resp.PrimaryKeys[nodeResponse.PrimaryKey] = 1
+		} else {
+			resp.PrimaryKeys[nodeResponse.PrimaryKey]++
+		}
+
 	NEXT:
 		// Return early if all nodes have responded. This allows us to avoid
 		// waiting for the full timeout when there is nothing left to do.
@@ -97,8 +107,9 @@ func (k *KeyManager) streamKeyResp(resp *KeyResponse, ch <-chan NodeResponse) {
 // KeyResponse for uniform response handling.
 func (k *KeyManager) handleKeyRequest(key, query string, opts *KeyRequestOptions) (*KeyResponse, error) {
 	resp := &KeyResponse{
-		Messages: make(map[string]string),
-		Keys:     make(map[string]int),
+		Messages:    make(map[string]string),
+		Keys:        make(map[string]int),
+		PrimaryKeys: make(map[string]int),
 	}
 	qName := internalQueryName(query)
 

--- a/serf/keymanager_test.go
+++ b/serf/keymanager_test.go
@@ -289,7 +289,7 @@ func TestSerf_ListKeys(t *testing.T) {
 	}
 
 	found := false
-	for key, _ := range resp.Keys {
+	for key := range resp.Keys {
 		if key == extraKey {
 			found = true
 		}
@@ -302,6 +302,18 @@ func TestSerf_ListKeys(t *testing.T) {
 	for key, num := range resp.Keys {
 		if key == extraKey && num != 1 {
 			t.Fatalf("Expected 1 nodes with key %s but have %d", extraKey, num)
+		}
+	}
+
+	// PrimaryKeys should be set
+	if len(resp.PrimaryKeys) != 1 {
+		t.Fatalf("Expected one primary key, but have %v", len(resp.PrimaryKeys))
+	}
+
+	// extraKey is not the primary
+	for key := range resp.PrimaryKeys {
+		if key == extraKey {
+			t.Fatal("extrakey shouldn't be the primary key")
 		}
 	}
 }


### PR DESCRIPTION
This PR modifies the key list response and adds a field for the primary key of a node. They will be accumulated similarly to the other keys.