### PR TITLE
Add the ability for per-node reconnect timeouts to be specified by a Serf user

### DIFF
--- a/coordinate/performance_test.go
+++ b/coordinate/performance_test.go
@@ -75,7 +75,7 @@ func TestPerformance_Height(t *testing.T) {
 
 	// Make sure the height looks reasonable with the regular nodes all in a
 	// plane, and the center node up above.
-	for i, _ := range clients {
+	for i := range clients {
 		coord := clients[i].GetCoordinate()
 		if i == 0 {
 			if coord.Height < 0.97*radius.Seconds() {
@@ -146,7 +146,7 @@ func TestPerformance_Drift(t *testing.T) {
 		}
 
 		mid := make([]float64, config.Dimensionality)
-		for i, _ := range mid {
+		for i := range mid {
 			mid[i] = min.Vec[i] + (max.Vec[i]-min.Vec[i])/2
 		}
 		return magnitude(mid)

--- a/coordinate/phantom.go
+++ b/coordinate/phantom.go
@@ -11,7 +11,7 @@ import (
 // given config.
 func GenerateClients(nodes int, config *Config) ([]*Client, error) {
 	clients := make([]*Client, nodes)
-	for i, _ := range clients {
+	for i := range clients {
 		client, err := NewClient(config)
 		if err != nil {
 			return nil, err
@@ -146,7 +146,7 @@ func Simulate(clients []*Client, truth [][]time.Duration, cycles int) {
 
 	nodes := len(clients)
 	for cycle := 0; cycle < cycles; cycle++ {
-		for i, _ := range clients {
+		for i := range clients {
 			if j := rand.Intn(nodes); j != i {
 				c := clients[j].GetCoordinate()
 				rtt := truth[i][j]

--- a/coordinate/util_test.go
+++ b/coordinate/util_test.go
@@ -21,7 +21,7 @@ func verifyEqualVectors(t *testing.T, vec1 []float64, vec2 []float64) {
 		t.Fatalf("vector length mismatch, %d != %d", len(vec1), len(vec2))
 	}
 
-	for i, _ := range vec1 {
+	for i := range vec1 {
 		verifyEqualFloats(t, vec1[i], vec2[i])
 	}
 }

--- a/serf/config.go
+++ b/serf/config.go
@@ -254,6 +254,10 @@ type Config struct {
 	// WARNING: this should ONLY be used in tests
 	messageDropper func(typ messageType) bool
 
+	// ReconnectTimeoutOverride is an optional interface which when present allows
+	// the application to cause reaping of a node to happen when it otherwise wouldn't
+	ReconnectTimeoutOverride ReconnectTimeoutOverrider
+
 	// ValidateNodeNames controls whether nodenames only
 	// contain alphanumeric, dashes and '.'characters
 	// and sets maximum length to 128 characters

--- a/serf/merge_delegate_test.go
+++ b/serf/merge_delegate_test.go
@@ -1,0 +1,102 @@
+package serf
+
+import (
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/memberlist"
+)
+
+func TestValidateMemberInfo(t *testing.T) {
+	type testCase struct {
+		name              string
+		addr              net.IP
+		meta              []byte
+		validateNodeNames bool
+		err               string
+	}
+
+	cases := map[string]testCase{
+		"invalid-name-chars": {
+			name:              "space not allowed",
+			addr:              []byte{1, 2, 3, 4},
+			validateNodeNames: true,
+			err:               "Node name contains invalid characters",
+		},
+		"invalid-name-chars-not-validated": {
+			name:              "space not allowed",
+			addr:              []byte{1, 2, 3, 4},
+			validateNodeNames: false,
+		},
+		"invalid-name-len": {
+			name:              strings.Repeat("abcd", 33),
+			addr:              []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+			validateNodeNames: true,
+			err:               "Node name is 132 characters.", // 33 * 4
+		},
+		"invalid-name-len-not-validated": {
+			name:              strings.Repeat("abcd", 33),
+			addr:              []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+			validateNodeNames: false,
+		},
+		"invalid-ip": {
+			name: "test",
+			addr: []byte{1, 2}, // length has to be 4 or 16
+			err:  "IP byte length is invalid",
+		},
+		"invalid-ip-2": {
+			name: "test",
+			addr: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17}, // length has to be 4 or 16
+			err:  "IP byte length is invalid",
+		},
+		"meta-too-long": {
+			name: "test",
+			addr: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+			meta: []byte(strings.Repeat("a", 513)),
+			err:  "Encoded length of tags exceeds limit",
+		},
+		"ipv4-okay": {
+			name: "test",
+			addr: []byte{1, 1, 1, 1},
+		},
+		"ipv6-okay": {
+			name: "test",
+			addr: []byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+		},
+	}
+
+	for name, tcase := range cases {
+		t.Run(name, func(t *testing.T) {
+
+			delegate := mergeDelegate{
+				serf: &Serf{
+					config: &Config{
+						ValidateNodeNames: tcase.validateNodeNames,
+					},
+				},
+			}
+
+			node := &memberlist.Node{
+				Name: tcase.name,
+				Addr: tcase.addr,
+				Meta: tcase.meta,
+			}
+
+			err := delegate.validateMemberInfo(node)
+
+			if tcase.err == "" {
+				if err != nil {
+					t.Fatalf("Encountered an unexpected error when validating member info: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("Did not encounter the expected error of %q", tcase.err)
+				}
+				if !strings.Contains(err.Error(), tcase.err) {
+					t.Fatalf("Member info validation failed with a different error than expected. Expected: %q, Actual: %q", tcase.err, err.Error())
+				}
+			}
+		})
+	}
+}

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -1894,15 +1894,19 @@ func (s *Serf) NumNodes() (numNodes int) {
 // ValidateNodeNames verifies the NodeName contains
 // only alphanumeric, -, or . and is under 128 chracters
 func (s *Serf) ValidateNodeNames() error {
+	return s.validateNodeName(s.config.NodeName)
+}
+
+func (s *Serf) validateNodeName(name string) error {
 	if s.config.ValidateNodeNames {
 		var InvalidNameRe = regexp.MustCompile(`[^A-Za-z0-9\-\.]+`)
-		if InvalidNameRe.MatchString(s.config.NodeName) {
-			return fmt.Errorf("NodeName contains invalid characters %v , Valid characters include "+
-				"all alpha-numerics and dashes and '.' ", s.config.NodeName)
+		if InvalidNameRe.MatchString(name) {
+			return fmt.Errorf("Node name contains invalid characters %v , Valid characters include "+
+				"all alpha-numerics and dashes and '.' ", name)
 		}
-		if len(s.config.NodeName) > MaxNodeNameLength {
-			return fmt.Errorf("NodeName is %v characters. "+
-				"Valid length is between 1 and 128 characters", len(s.config.NodeName))
+		if len(name) > MaxNodeNameLength {
+			return fmt.Errorf("Node name is %v characters. "+
+				"Valid length is between 1 and 128 characters", len(name))
 		}
 	}
 	return nil


### PR DESCRIPTION
There are actually 3 commits in this PR:

* The first commit is to make the golangci linter happy with simplifying some range expressions.
* The second commit fixes an issue recently introduced that would cause all messages to be rejected for invalid reasons.
* The third commit is the real work of this PR which allows an application using serf to override the reconnect timeout on a per-node basis. There is an interface they can optionally provide and serf will use its only method to request the per-node timeout. If no interface is provided then the normal reconnect timeout is used.

TODOS:
- [x] Tests