### PR TITLE
Export `LogWriter` to enable embedding `serf`

### DIFF
--- a/cmd/serf/command/agent/command.go
+++ b/cmd/serf/command/agent/command.go
@@ -358,8 +358,8 @@ func (c *Command) setupAgent(config *Config, logOutput io.Writer) *Agent {
 	return agent
 }
 
-// setupLoggers is used to setup the logGate, logWriter, and our logOutput
-func (c *Command) setupLoggers(config *Config) (*GatedWriter, *logWriter, io.Writer) {
+// setupLoggers is used to setup the logGate, LogWriter, and our logOutput
+func (c *Command) setupLoggers(config *Config) (*GatedWriter, *LogWriter, io.Writer) {
 	// Setup logging. First create the gated log writer, which will
 	// store logs until we're ready to show them. Then create the level
 	// filter, filtering logs of the specified level.
@@ -404,7 +404,7 @@ func (c *Command) setupLoggers(config *Config) (*GatedWriter, *logWriter, io.Wri
 
 // startAgent is used to start the agent and IPC
 func (c *Command) startAgent(config *Config, agent *Agent,
-	logWriter *logWriter, logOutput io.Writer) *AgentIPC {
+	logWriter *LogWriter, logOutput io.Writer) *AgentIPC {
 	// Add the script event handlers
 	c.scriptHandler = &ScriptEventHandler{
 		SelfFunc: func() serf.Member { return agent.Serf().LocalMember() },

--- a/cmd/serf/command/agent/ipc.go
+++ b/cmd/serf/command/agent/ipc.go
@@ -243,7 +243,7 @@ type AgentIPC struct {
 	clients   map[string]*IPCClient
 	listener  net.Listener
 	logger    *log.Logger
-	logWriter *logWriter
+	logWriter *LogWriter
 	stop      bool
 	stopCh    chan struct{}
 }
@@ -327,7 +327,7 @@ func (c *IPCClient) RegisterQuery(q *serf.Query) uint64 {
 
 // NewAgentIPC is used to create a new Agent IPC handler
 func NewAgentIPC(agent *Agent, authKey string, listener net.Listener,
-	logOutput io.Writer, logWriter *logWriter) *AgentIPC {
+	logOutput io.Writer, logWriter *LogWriter) *AgentIPC {
 	if logOutput == nil {
 		logOutput = os.Stderr
 	}

--- a/cmd/serf/command/agent/log_writer.go
+++ b/cmd/serf/command/agent/log_writer.go
@@ -10,10 +10,10 @@ type LogHandler interface {
 	HandleLog(string)
 }
 
-// logWriter implements io.Writer so it can be used as a log sink.
+// LogWriter implements io.Writer so it can be used as a log sink.
 // It maintains a circular buffer of logs, and a set of handlers to
 // which it can stream the logs to.
-type logWriter struct {
+type LogWriter struct {
 	sync.Mutex
 	logs     []string
 	index    int
@@ -21,8 +21,8 @@ type logWriter struct {
 }
 
 // NewLogWriter creates a logWriter with the given buffer capacity
-func NewLogWriter(buf int) *logWriter {
-	return &logWriter{
+func NewLogWriter(buf int) *LogWriter {
+	return &LogWriter{
 		logs:     make([]string, buf),
 		index:    0,
 		handlers: make(map[LogHandler]struct{}),
@@ -31,7 +31,7 @@ func NewLogWriter(buf int) *logWriter {
 
 // RegisterHandler adds a log handler to receive logs, and sends
 // the last buffered logs to the handler
-func (l *logWriter) RegisterHandler(lh LogHandler) {
+func (l *LogWriter) RegisterHandler(lh LogHandler) {
 	l.Lock()
 	defer l.Unlock()
 
@@ -55,14 +55,14 @@ func (l *logWriter) RegisterHandler(lh LogHandler) {
 }
 
 // DeregisterHandler removes a LogHandler and prevents more invocations
-func (l *logWriter) DeregisterHandler(lh LogHandler) {
+func (l *LogWriter) DeregisterHandler(lh LogHandler) {
 	l.Lock()
 	defer l.Unlock()
 	delete(l.handlers, lh)
 }
 
 // Write is used to accumulate new logs
-func (l *logWriter) Write(p []byte) (n int, err error) {
+func (l *LogWriter) Write(p []byte) (n int, err error) {
 	l.Lock()
 	defer l.Unlock()
 


### PR DESCRIPTION
`LogWriter` must be exported to enable other golang projects to easily embed the `agent` Command.