### PR TITLE
ci: use latest Go version and fix a flaky test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 executors:
   go:
     docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:1.14.1
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.16
     environment:
       - TEST_RESULTS: /tmp/test-results # path to where test results are saved
 
@@ -13,19 +13,7 @@ jobs:
     executor: go
     steps:
       - checkout
-
-      # Restore go module cache if there is one
-      - restore_cache:
-          keys:
-            - serf-modcache-v1-{{ checksum "go.mod" }}
-
       - run: go mod download
-
-      # Save go module cache if the go.mod file has changed
-      - save_cache:
-          key: serf-modcache-v1-{{ checksum "go.mod" }}
-          paths:
-            - "/go/pkg/mod"
 
       # check go fmt output because it does not report non-zero when there are fmt changes
       - run:
@@ -45,12 +33,6 @@ jobs:
       - checkout
       - run: mkdir -p $TEST_RESULTS
       - run: make bin
-
-      # Restore go module cache if there is one
-      - restore_cache:
-          keys:
-            - serf-modcache-v1-{{ checksum "go.mod" }}
-
       - run: sudo apt-get update && sudo apt-get install -y rsyslog
       - run: sudo service rsyslog start
       # run go tests with gotestsum

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -36,7 +36,7 @@ fi
 echo "==> Building..."
 gox \
     -os="${XC_OS}" \
-    -osarch="!darwin/arm" \
+    -osarch="!darwin/arm !darwin/386" \
     -arch="${XC_ARCH}" \
     -ldflags "-X ${GIT_IMPORT}.GitCommit='${GIT_COMMIT}${GIT_DIRTY}'" \
     -output "pkg/{{.OS}}_{{.Arch}}/serf" \

--- a/serf/event_test.go
+++ b/serf/event_test.go
@@ -9,6 +9,7 @@ import (
 // testEvents tests that the given node had the given sequence of events
 // on the event channel.
 func testEvents(t *testing.T, ch <-chan Event, node string, expected []EventType) {
+	t.Helper()
 	actual := make([]EventType, 0, len(expected))
 
 TESTEVENTLOOP:

--- a/serf/serf_test.go
+++ b/serf/serf_test.go
@@ -459,7 +459,7 @@ func TestSerf_RemoveFailed_eventsLeave(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	time.Sleep(s2Config.MemberlistConfig.ProbeInterval * 3)
+	time.Sleep(s2Config.MemberlistConfig.ProbeInterval * 5)
 
 	if err := s1.RemoveFailedNode(s2Config.NodeName); err != nil {
 		t.Fatalf("err: %v", err)
@@ -2950,7 +2950,7 @@ func waitUntilNumNodes(t *testing.T, desiredNodes int, serfs ...*Serf) {
 		t.Helper()
 		for i, s := range serfs {
 			if n := s.NumNodes(); desiredNodes != n {
-				r.Fatalf("s%d got %d expected %d", (i + 1), n, desiredNodes)
+				r.Fatalf("s%d got %d expected %d", i+1, n, desiredNodes)
 			}
 		}
 	})

--- a/serf/serf_test.go
+++ b/serf/serf_test.go
@@ -2034,11 +2034,12 @@ func TestSerf_Query(t *testing.T) {
 				}
 				q := e.(*Query)
 				if err := q.Respond([]byte("test")); err != nil {
-					t.Fatalf("err: %v", err)
+					t.Errorf("err: %v", err)
 				}
 				return
 			case <-time.After(time.Second):
-				t.Fatalf("timeout")
+				t.Errorf("timeout")
+				return
 			}
 		}
 	}()
@@ -2138,11 +2139,12 @@ func TestSerf_Query_Filter(t *testing.T) {
 				}
 				q := e.(*Query)
 				if err := q.Respond([]byte("test")); err != nil {
-					t.Fatalf("err: %v", err)
+					t.Errorf("err: %v", err)
 				}
 				return
 			case <-time.After(time.Second):
-				t.Fatalf("timeout")
+				t.Errorf("timeout")
+				return
 			}
 		}
 	}()


### PR DESCRIPTION
Also remove module cache, because downloading from the module proxy is faster than using the cache.