### PR TITLE
Add source node getter

### DIFF
--- a/serf/event.go
+++ b/serf/event.go
@@ -121,6 +121,11 @@ func (q *Query) String() string {
 	return fmt.Sprintf("query: %s", q.Name)
 }
 
+// SourceNode returns the name of the node initiating the query
+func (q *Query) SourceNode() string {
+	return q.sourceNode
+}
+
 // Deadline returns the time by which a response must be sent
 func (q *Query) Deadline() time.Time {
 	return q.deadline


### PR DESCRIPTION
Users of the `serf` library may need to perform actions out of serf regarding the node initiating a query, therefore being able to access this information will be useful.