### PR TITLE
Fix broken CICD tests

### DIFF
--- a/serf/serf_test.go
+++ b/serf/serf_test.go
@@ -979,6 +979,7 @@ func TestSerf_reconnect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	defer s2.Shutdown()
 
 	waitUntilNumNodes(t, 2, s1, s2)
 	// time.Sleep(s1Config.ReconnectInterval * 5)


### PR DESCRIPTION
This test was causing seemingly unrelated failures in other tests due to not releasing the ip address listener correctly.