### PR TITLE
Enhance mDNS Functionality

### DIFF
--- a/cmd/serf/command/agent/config.go
+++ b/cmd/serf/command/agent/config.go
@@ -48,7 +48,9 @@ type dirEnts []os.FileInfo
 type MDNSConfig struct {
 	// Interface is used to provide a binding interface to use for mDNS.
 	// if not set, iface will be used.
-	Interface string `mapstructure:"interface"`
+	Interface   string `mapstructure:"interface"`
+	DisableIPv4 bool   `mapstructure:"disable_ipv4"`
+	DisableIPv6 bool   `mapstructure:"disable_ipv6"`
 }
 
 // Config is the configuration that can be set for an Agent. Some of these
@@ -457,6 +459,14 @@ func MergeConfig(a, b *Config) *Config {
 
 	if b.MDNS.Interface != "" {
 		result.MDNS.Interface = b.MDNS.Interface
+	}
+
+	if b.MDNS.DisableIPv4 == true {
+		result.MDNS.DisableIPv4 = true
+	}
+
+	if b.MDNS.DisableIPv6 == true {
+		result.MDNS.DisableIPv6 = true
 	}
 
 	if b.ReconnectInterval != 0 {

--- a/cmd/serf/command/agent/mdns.go
+++ b/cmd/serf/command/agent/mdns.go
@@ -21,18 +21,21 @@ const (
 // AgentMDNS is used to advertise ourself using mDNS and to
 // attempt to join peers periodically using mDNS queries.
 type AgentMDNS struct {
-	agent    *Agent
-	discover string
-	logger   *log.Logger
-	seen     map[string]struct{}
-	server   *mdns.Server
-	replay   bool
-	iface    *net.Interface
+	agent       *Agent
+	discover    string
+	logger      *log.Logger
+	seen        map[string]struct{}
+	server      *mdns.Server
+	replay      bool
+	iface       *net.Interface
+	ipModes     []string
+	disableIPv4 bool
+	disableIPv6 bool
 }
 
 // NewAgentMDNS is used to create a new AgentMDNS
 func NewAgentMDNS(agent *Agent, logOutput io.Writer, replay bool,
-	node, discover string, iface *net.Interface, bind net.IP, port int) (*AgentMDNS, error) {
+	node, discover string, iface *net.Interface, bind net.IP, port int, MDNSConfig MDNSConfig) (*AgentMDNS, error) {
 	// Create the service
 	service, err := mdns.NewMDNSService(
 		node,
@@ -60,13 +63,15 @@ func NewAgentMDNS(agent *Agent, logOutput io.Writer, replay bool,
 
 	// Initialize the AgentMDNS
 	m := &AgentMDNS{
-		agent:    agent,
-		discover: discover,
-		logger:   log.New(logOutput, "", log.LstdFlags),
-		seen:     make(map[string]struct{}),
-		server:   server,
-		replay:   replay,
-		iface:    iface,
+		agent:       agent,
+		discover:    discover,
+		logger:      log.New(logOutput, "", log.LstdFlags),
+		seen:        make(map[string]struct{}),
+		server:      server,
+		replay:      replay,
+		iface:       iface,
+		disableIPv4: MDNSConfig.DisableIPv4,
+		disableIPv6: MDNSConfig.DisableIPv6,
 	}
 
 	// Start the background workers
@@ -123,9 +128,11 @@ func (m *AgentMDNS) run() {
 // poll is invoked periodically to check for new hosts
 func (m *AgentMDNS) poll(hosts chan *mdns.ServiceEntry) {
 	params := mdns.QueryParam{
-		Service:   mdnsName(m.discover),
-		Interface: m.iface,
-		Entries:   hosts,
+		Service:     mdnsName(m.discover),
+		Interface:   m.iface,
+		Entries:     hosts,
+		DisableIPv4: m.disableIPv4,
+		DisableIPv6: m.disableIPv6,
 	}
 	if err := mdns.Query(&params); err != nil {
 		m.logger.Printf("[ERR] agent.mdns: Failed to poll for new hosts: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-msgpack/v2 v2.1.2
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/logutils v1.0.0
-	github.com/hashicorp/mdns v1.0.4
+	github.com/hashicorp/mdns v1.0.5
 	github.com/hashicorp/memberlist v0.5.1
 	github.com/mitchellh/cli v1.1.5
 	github.com/mitchellh/mapstructure v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iP
 github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
-github.com/hashicorp/mdns v1.0.4 h1:sY0CMhFmjIPDMlTB+HfymFHCaYLhgifZ0QhjaYKD/UQ=
-github.com/hashicorp/mdns v1.0.4/go.mod h1:mtBihi+LeNXGtG8L9dX59gAEa12BDtBQSp4v/YAJqrc=
+github.com/hashicorp/mdns v1.0.5 h1:1M5hW1cunYeoXOqHwEb/GBDDHAFo0Yqb/uz/beC6LbE=
+github.com/hashicorp/mdns v1.0.5/go.mod h1:mtBihi+LeNXGtG8L9dX59gAEa12BDtBQSp4v/YAJqrc=
 github.com/hashicorp/memberlist v0.5.1 h1:mk5dRuzeDNis2bi6LLoQIXfMH7JQvAzt3mQD0vNZZUo=
 github.com/hashicorp/memberlist v0.5.1/go.mod h1:zGDXV6AqbDTKTM6yxW0I4+JtFzZAJVoIPvss4hV8F24=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=


### PR DESCRIPTION
This PR:
* Allows specifying `iface` for mDNS: In our use case, we disable multicast on the interface that Serf binds to. However, we have another network where Serf can discover neighbors using multicast.
* Updates mDNS to v1.0.5: mDNS v1.0.5 enables the disabling of one of the IP stacks.
* Allows disabling one of the IP stacks in the config file and CLI arguments.
