### PR TITLE
remove unnecessary check. just overwrite.

### DIFF
--- a/serf/coalesce_member.go
+++ b/serf/coalesce_member.go
@@ -44,14 +44,6 @@ func (c *memberEventCoalescer) Flush(outCh chan<- Event) {
 	// Coalesce the various events we got into a single set of events.
 	events := make(map[EventType]*MemberEvent)
 	for name, cevent := range c.latestEvents {
-		previous, ok := c.lastEvents[name]
-
-		// If we sent the same event before, then ignore
-		// unless it is a MemberUpdate
-		if ok && previous == cevent.Type && cevent.Type != EventMemberUpdate {
-			continue
-		}
-
 		// Update our last event
 		c.lastEvents[name] = cevent.Type
 


### PR DESCRIPTION
it is unnecessary to check for event of the same type and skip it. if we overwrite event of the same type, it's the same as skipping it. it doesn't matter if that event is update event or not.