### PR TITLE
s2 should see its status as alive after fixing issue #18

### DIFF
--- a/serf/serf_test.go
+++ b/serf/serf_test.go
@@ -1699,17 +1699,17 @@ func TestSerf_joinLeaveJoin(t *testing.T) {
 			r.Fatalf("s2 members: %d", s2.NumNodes())
 		}
 
-		// s1 should see the node as alive
-		mems := s1.Members()
-		anyLeft := false
+		// s2 should see the itself as alive
+		mems := s2.Members()
+		anyLeaving := false
 		for _, m := range mems {
-			if m.Status == StatusLeft {
-				anyLeft = true
+			if m.Status == StatusLeaving {
+				anyLeaving = true
 				break
 			}
 		}
-		if anyLeft {
-			r.Fatalf("all nodes should be alive!")
+		if anyLeaving {
+			t.Fatalf("all nodes should be alive!")
 		}
 	})
 }


### PR DESCRIPTION
the test doesn't reflect the fix of issue #18. before apply fixing, a node rejoins the cluster still sees itself in "leaving" state while other nodes see it as alive. now, it sees itself as alive.