### PR TITLE
improve readability of member event coalescer

### DIFF
--- a/serf/serf.go
+++ b/serf/serf.go
@@ -293,8 +293,8 @@ func Create(conf *Config) (*Serf, error) {
 	// Check if serf member event coalescing is enabled
 	if conf.CoalescePeriod > 0 && conf.QuiescentPeriod > 0 && conf.EventCh != nil {
 		c := &memberEventCoalescer{
-			lastEvents:   make(map[string]EventType),
-			latestEvents: make(map[string]coalesceEvent),
+			lastEvents: make(map[string]*nodeEvent),
+			newEvents:  make(map[string]*nodeEvent),
 		}
 
 		conf.EventCh = coalescedEventCh(conf.EventCh, serf.shutdownCh,


### PR DESCRIPTION
- lastEvents and latestEvents are easily confused with one another. recommend using newEvents. coalesceEvent is not descriptive of its role. it is event for a node, so call it nodeEvent.
- using only event types for lastEvents is too clever and make the code harder to reason about. furthermore, it doesn't help in checking duplicating member-update-event. stick with nodeEvent for lastEvents and it handles duplication with ease.