### PR TITLE
remove deprecated ioutil.

### DIFF
--- a/cmd/serf/command/agent/agent.go
+++ b/cmd/serf/command/agent/agent.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -326,7 +325,7 @@ func (a *Agent) loadTagsFile(tagsFile string) error {
 	}
 
 	if _, err := os.Stat(tagsFile); err == nil {
-		tagData, err := ioutil.ReadFile(tagsFile)
+		tagData, err := os.ReadFile(tagsFile)
 		if err != nil {
 			return fmt.Errorf("Failed to read tags file: %s", err)
 		}
@@ -349,7 +348,7 @@ func (a *Agent) writeTagsFile(tags map[string]string) error {
 	}
 
 	// Use 0600 for permissions, in case tag data is sensitive
-	if err = ioutil.WriteFile(a.agentConf.TagsFile, encoded, 0600); err != nil {
+	if err = os.WriteFile(a.agentConf.TagsFile, encoded, 0600); err != nil {
 		return fmt.Errorf("Failed to write tags file: %s", err)
 	}
 
@@ -393,7 +392,7 @@ func (a *Agent) loadKeyringFile(keyringFile string) error {
 	}
 
 	// Read in the keyring file data
-	keyringData, err := ioutil.ReadFile(keyringFile)
+	keyringData, err := os.ReadFile(keyringFile)
 	if err != nil {
 		return fmt.Errorf("Failed to read keyring file: %s", err)
 	}

--- a/cmd/serf/command/agent/agent_test.go
+++ b/cmd/serf/command/agent/agent_test.go
@@ -5,7 +5,6 @@ package agent
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -128,11 +127,7 @@ func TestAgentTagsFile(t *testing.T) {
 		"datacenter": "us-east",
 	}
 
-	td, err := ioutil.TempDir("", "serf")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 
 	ip1, returnFn1 := testutil.TakeIP()
 	defer returnFn1()
@@ -153,7 +148,7 @@ func TestAgentTagsFile(t *testing.T) {
 
 	testutil.Yield()
 
-	err = a1.SetTags(tags)
+	err := a1.SetTags(tags)
 
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -248,11 +243,7 @@ func TestAgentKeyringFile(t *testing.T) {
 		"5K9OtfP7efFrNKe5WCQvXvnaXJ5cWP0SvXiwe0kkjM4=",
 	}
 
-	td, err := ioutil.TempDir("", "serf")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 
 	keyringFile := filepath.Join(td, "keyring.json")
 
@@ -265,7 +256,7 @@ func TestAgentKeyringFile(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := ioutil.WriteFile(keyringFile, encodedKeys, 0600); err != nil {
+	if err := os.WriteFile(keyringFile, encodedKeys, 0600); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -299,21 +290,17 @@ func TestAgentKeyringFile_BadOptions(t *testing.T) {
 }
 
 func TestAgentKeyringFile_NoKeys(t *testing.T) {
-	dir, err := ioutil.TempDir("", "serf")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	keysFile := filepath.Join(dir, "keyring")
-	if err := ioutil.WriteFile(keysFile, []byte("[]"), 0600); err != nil {
+	if err := os.WriteFile(keysFile, []byte("[]"), 0600); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	agentConfig := DefaultConfig()
 	agentConfig.KeyringFile = keysFile
 
-	_, err = Create(agentConfig, serf.DefaultConfig(), nil)
+	_, err := Create(agentConfig, serf.DefaultConfig(), nil)
 	if err == nil {
 		t.Fatalf("should have errored")
 	}

--- a/cmd/serf/command/agent/config_test.go
+++ b/cmd/serf/command/agent/config_test.go
@@ -6,7 +6,6 @@ package agent
 import (
 	"bytes"
 	"encoding/base64"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -535,7 +534,7 @@ func TestReadConfigPaths_badPath(t *testing.T) {
 }
 
 func TestReadConfigPaths_file(t *testing.T) {
-	tf, err := ioutil.TempFile("", "serf")
+	tf, err := os.CreateTemp("", "serf")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -554,26 +553,22 @@ func TestReadConfigPaths_file(t *testing.T) {
 }
 
 func TestReadConfigPaths_dir(t *testing.T) {
-	td, err := ioutil.TempDir("", "serf")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 
-	err = ioutil.WriteFile(filepath.Join(td, "a.json"),
+	err := os.WriteFile(filepath.Join(td, "a.json"),
 		[]byte(`{"node_name": "bar"}`), 0644)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	err = ioutil.WriteFile(filepath.Join(td, "b.json"),
+	err = os.WriteFile(filepath.Join(td, "b.json"),
 		[]byte(`{"node_name": "baz"}`), 0644)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	// A non-json file, shouldn't be read
-	err = ioutil.WriteFile(filepath.Join(td, "c"),
+	err = os.WriteFile(filepath.Join(td, "c"),
 		[]byte(`{"node_name": "bad"}`), 0644)
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/cmd/serf/command/agent/event_handler_test.go
+++ b/cmd/serf/command/agent/event_handler_test.go
@@ -5,7 +5,6 @@ package agent
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"testing"
@@ -51,7 +50,7 @@ done
 // agent. It returns the path to the event script itself and a path to
 // the file that will contain the events that that script receives.
 func testEventScript(t *testing.T, script string) (string, string) {
-	scriptFile, err := ioutil.TempFile("", "serf")
+	scriptFile, err := os.CreateTemp("", "serf")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -61,7 +60,7 @@ func testEventScript(t *testing.T, script string) (string, string) {
 		t.Fatalf("err: %v", err)
 	}
 
-	resultFile, err := ioutil.TempFile("", "serf-result")
+	resultFile, err := os.CreateTemp("", "serf-result")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -111,7 +110,7 @@ func TestScriptEventHandler(t *testing.T) {
 
 	h.HandleEvent(event)
 
-	result, err := ioutil.ReadFile(results)
+	result, err := os.ReadFile(results)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -152,7 +151,7 @@ func TestScriptUserEventHandler(t *testing.T) {
 
 	h.HandleEvent(userEvent)
 
-	result, err := ioutil.ReadFile(results)
+	result, err := os.ReadFile(results)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -191,7 +190,7 @@ func TestScriptQueryEventHandler(t *testing.T) {
 
 	h.HandleEvent(query)
 
-	result, err := ioutil.ReadFile(results)
+	result, err := os.ReadFile(results)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/cmd/serf/command/agent/log_levels.go
+++ b/cmd/serf/command/agent/log_levels.go
@@ -4,7 +4,7 @@
 package agent
 
 import (
-	"io/ioutil"
+	"io"
 
 	"github.com/hashicorp/logutils"
 )
@@ -15,7 +15,7 @@ func LevelFilter() *logutils.LevelFilter {
 	return &logutils.LevelFilter{
 		Levels:   []logutils.LogLevel{"TRACE", "DEBUG", "INFO", "WARN", "ERR"},
 		MinLevel: "INFO",
-		Writer:   ioutil.Discard,
+		Writer:   io.Discard,
 	}
 }
 

--- a/cmd/serf/main.go
+++ b/cmd/serf/main.go
@@ -5,7 +5,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 
@@ -13,7 +13,7 @@ import (
 )
 
 func main() {
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 
 	// Get the command line args. We shortcut "--version" and "-v" to
 	// just show the version.

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -8,7 +8,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"net"
@@ -1872,7 +1871,7 @@ func (s *Serf) writeKeyringFile() error {
 	}
 
 	// Use 0600 for permissions because key data is sensitive
-	if err = ioutil.WriteFile(s.config.KeyringFile, encodedKeys, 0600); err != nil {
+	if err = os.WriteFile(s.config.KeyringFile, encodedKeys, 0600); err != nil {
 		return fmt.Errorf("Failed to write keyring file: %s", err)
 	}
 

--- a/serf/serf_test.go
+++ b/serf/serf_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -1768,11 +1767,7 @@ func TestSerf_Join_IgnoreOld(t *testing.T) {
 }
 
 func TestSerf_SnapshotRecovery(t *testing.T) {
-	td, err := ioutil.TempDir("", "serf")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 
 	ip1, returnFn1 := testutil.TakeIP()
 	defer returnFn1()
@@ -1865,11 +1860,7 @@ func TestSerf_Leave_SnapshotRecovery(t *testing.T) {
 		t.Skip("test contains a data race")
 	}
 
-	td, err := ioutil.TempDir("", "serf")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 
 	ip1, returnFn1 := testutil.TakeIP()
 	defer returnFn1()
@@ -2446,11 +2437,7 @@ func TestSerf_WriteKeyringFile(t *testing.T) {
 	existing := "T9jncgl9mbLus+baTTa7q7nPSUrXwbDi2dhbtqir37s="
 	newKey := "HvY8ubRZMgafUOWvrOadwOckVa1wN3QWAo46FVKbVN8="
 
-	td, err := ioutil.TempDir("", "serf")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 
 	keyringFile := filepath.Join(td, "tags.json")
 
@@ -2483,7 +2470,7 @@ func TestSerf_WriteKeyringFile(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	content, err := ioutil.ReadFile(keyringFile)
+	content, err := os.ReadFile(keyringFile)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2513,7 +2500,7 @@ func TestSerf_WriteKeyringFile(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	content, err = ioutil.ReadFile(keyringFile)
+	content, err = os.ReadFile(keyringFile)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2533,7 +2520,7 @@ func TestSerf_WriteKeyringFile(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	content, err = ioutil.ReadFile(keyringFile)
+	content, err = os.ReadFile(keyringFile)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/serf/snapshot_test.go
+++ b/serf/snapshot_test.go
@@ -5,7 +5,6 @@ package serf
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"reflect"
@@ -14,11 +13,7 @@ import (
 )
 
 func TestSnapshotter(t *testing.T) {
-	td, err := ioutil.TempDir("", "serf")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 
 	clock := new(LamportClock)
 	outCh := make(chan Event, 64)
@@ -168,11 +163,7 @@ func TestSnapshotter(t *testing.T) {
 }
 
 func TestSnapshotter_forceCompact(t *testing.T) {
-	td, err := ioutil.TempDir("", "serf")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 
 	clock := new(LamportClock)
 	stopCh := make(chan struct{})
@@ -232,11 +223,7 @@ func TestSnapshotter_forceCompact(t *testing.T) {
 }
 
 func TestSnapshotter_leave(t *testing.T) {
-	td, err := ioutil.TempDir("", "serf")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 
 	clock := new(LamportClock)
 	stopCh := make(chan struct{})
@@ -313,11 +300,7 @@ func TestSnapshotter_leave(t *testing.T) {
 }
 
 func TestSnapshotter_leave_rejoin(t *testing.T) {
-	td, err := ioutil.TempDir("", "serf")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 
 	clock := new(LamportClock)
 	stopCh := make(chan struct{})
@@ -395,12 +378,8 @@ func TestSnapshotter_leave_rejoin(t *testing.T) {
 
 func TestSnapshotter_slowDiskNotBlockingEventCh(t *testing.T) {
 	t.Skip("Flaky test")
-	td, err := ioutil.TempDir("", "serf")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	td := t.TempDir()
 	t.Log("Temp dir", td)
-	defer os.RemoveAll(td)
 
 	clock := new(LamportClock)
 	stopCh := make(chan struct{})
@@ -481,12 +460,8 @@ func TestSnapshotter_slowDiskNotBlockingEventCh(t *testing.T) {
 }
 
 func TestSnapshotter_blockedUpstreamNotBlockingMemberlist(t *testing.T) {
-	td, err := ioutil.TempDir("", "serf")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	td := t.TempDir()
 	t.Log("Temp dir", td)
-	defer os.RemoveAll(td)
 
 	clock := new(LamportClock)
 	stopCh := make(chan struct{})


### PR DESCRIPTION
Replace usage of deprecated `io/ioutil` with functionally equivalent usage of `os` and `io` packages.