### PR TITLE
fix underflow when clock is 0

### DIFF
--- a/serf/snapshot.go
+++ b/serf/snapshot.go
@@ -347,9 +347,9 @@ func (s *Snapshotter) processMemberEvent(e MemberEvent) {
 // clock value. This is done after member events but should also be done
 // periodically due to race conditions with join and leave intents
 func (s *Snapshotter) updateClock() {
-	lastSeen := s.clock.Time() - 1
-	if lastSeen > s.lastClock {
-		s.lastClock = lastSeen
+	current := s.clock.Time() - 1
+	if current > s.lastClock+1 {
+		s.lastClock = current - 1
 		s.tryAppend(fmt.Sprintf("clock: %d\n", s.lastClock))
 	}
 }


### PR DESCRIPTION
when clock is 0, because it is uint64, 0 - 1 is underflow to math.MaxUint64. so snapshot clock will never be updated again because the first update give it the max value.