### PR TITLE
Add validation and warning for force-leave command

### DIFF
--- a/cmd/serf/command/force_leave.go
+++ b/cmd/serf/command/force_leave.go
@@ -47,7 +47,9 @@ func (c *ForceLeaveCommand) Run(args []string) int {
 	defer client.Close()
 
 	members, err := client.Members()
-	if err == nil {
+	if err != nil {
+		c.Ui.Output(fmt.Sprintf("Warning: could not query members (%s), broadcasting force-leave anyway", err))
+	} else {
 		found := false
 		for _, member := range members {
 			if member.Name == nodes[0] {

--- a/cmd/serf/command/force_leave.go
+++ b/cmd/serf/command/force_leave.go
@@ -46,24 +46,18 @@ func (c *ForceLeaveCommand) Run(args []string) int {
 	}
 	defer client.Close()
 
-	// Validate that the node exists in the cluster
 	members, err := client.Members()
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error querying members: %s", err))
-		return 1
-	}
-
-	nodeExists := false
-	for _, member := range members {
-		if member.Name == nodes[0] {
-			nodeExists = true
-			break
+	if err == nil {
+		found := false
+		for _, member := range members {
+			if member.Name == nodes[0] {
+				found = true
+				break
+			}
 		}
-	}
-
-	if !nodeExists {
-		c.Ui.Error(fmt.Sprintf("Node '%s' not found in cluster", nodes[0]))
-		return 1
+		if !found {
+			c.Ui.Output(fmt.Sprintf("Warning: node '%s' not found in local member list, broadcasting force-leave anyway", nodes[0]))
+		}
 	}
 
 	if prune {

--- a/cmd/serf/command/force_leave.go
+++ b/cmd/serf/command/force_leave.go
@@ -46,6 +46,26 @@ func (c *ForceLeaveCommand) Run(args []string) int {
 	}
 	defer client.Close()
 
+	// Validate that the node exists in the cluster
+	members, err := client.Members()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error querying members: %s", err))
+		return 1
+	}
+
+	nodeExists := false
+	for _, member := range members {
+		if member.Name == nodes[0] {
+			nodeExists = true
+			break
+		}
+	}
+
+	if !nodeExists {
+		c.Ui.Error(fmt.Sprintf("Node '%s' not found in cluster", nodes[0]))
+		return 1
+	}
+
 	if prune {
 		err = client.ForceLeavePrune(nodes[0])
 		if err != nil {

--- a/cmd/serf/command/force_leave_test.go
+++ b/cmd/serf/command/force_leave_test.go
@@ -97,6 +97,36 @@ func TestForceLeaveCommandRun_noAddrs(t *testing.T) {
 	}
 }
 
+func TestForceLeaveCommandRun_nonexistentNode(t *testing.T) {
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	ip2, returnFn2 := testutil.TakeIP()
+	defer returnFn2()
+
+	a1 := testAgent(t, ip1)
+	defer a1.Shutdown()
+
+	rpcAddr, ipc := testIPC(t, ip2, a1)
+	defer ipc.Shutdown()
+
+	ui := new(cli.MockUi)
+	c := &ForceLeaveCommand{Ui: ui}
+	args := []string{
+		"-rpc-addr=" + rpcAddr,
+		"nonexistent-node",
+	}
+
+	code := c.Run(args)
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got: %d", code)
+	}
+
+	if !strings.Contains(ui.ErrorWriter.String(), "not found") {
+		t.Fatalf("expected 'not found' error, got: %#v", ui.ErrorWriter.String())
+	}
+}
+
 func TestForceLeaveCommandRun_prune(t *testing.T) {
 	ip1, returnFn1 := testutil.TakeIP()
 	defer returnFn1()

--- a/cmd/serf/command/force_leave_test.go
+++ b/cmd/serf/command/force_leave_test.go
@@ -118,12 +118,12 @@ func TestForceLeaveCommandRun_nonexistentNode(t *testing.T) {
 	}
 
 	code := c.Run(args)
-	if code != 1 {
-		t.Fatalf("expected exit code 1, got: %d", code)
+	if code != 0 {
+		t.Fatalf("expected exit code 0 (force-leave is idempotent), got: %d", code)
 	}
 
-	if !strings.Contains(ui.ErrorWriter.String(), "not found") {
-		t.Fatalf("expected 'not found' error, got: %#v", ui.ErrorWriter.String())
+	if !strings.Contains(ui.OutputWriter.String(), "not found") {
+		t.Fatalf("expected 'not found' warning in output, got: %#v", ui.OutputWriter.String())
 	}
 }
 


### PR DESCRIPTION
The force-leave command did not validate whether the specified node exists in the cluster, giving no visual indication when operating on a non-member. This made it difficult for operators to distinguish between successful operations and no-ops.

## What Changed

Query the member list before broadcasting force-leave. If the node is not found, emit a warning. If the member query fails, emit a warning about the failure but continue with force-leave (maintaining idempotent behavior with exit code 0).

This provides better observability in normal operations while remaining robust during degraded network conditions.

Adds test coverage for the nonexistent node scenario.

Fixes #500