### PR TITLE
compliance: add/update copyright headers and copywrite CI

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,0 +1,9 @@
+# Copyright IBM Corp. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+schema_version = 1
+
+project {
+  license        = "MPL-2.0"
+  copyright_year = 2013
+}

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2013, 2025
+# Copyright IBM Corp. 2013, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 version: 2

--- a/.github/workflows/copywrite.yml
+++ b/.github/workflows/copywrite.yml
@@ -1,0 +1,24 @@
+name: Check Copywrite Headers
+
+on:
+  pull_request:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  copywrite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636 # v1.1.3
+        name: Setup Copywrite
+        with:
+          version: v0.25.3
+          archive-checksum: e43f4b72fff3f219c5a5f883438d63edd5b68f5bea90a5d18abb3001c8c3aedc
+      - name: Check Header Compliance
+        run: make copywriteheaders
+permissions:
+  contents: read

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2013, 2025
+# Copyright IBM Corp. 2013, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 version: "2"

--- a/.release/release-metadata.hcl
+++ b/.release/release-metadata.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2013, 2025
+# Copyright IBM Corp. 2013, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 url_license = "https://github.com/hashicorp/serf/blob/master/LICENSE"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -21,6 +21,9 @@ format:
 	@echo "--> Running go fmt"
 	@go fmt $(GOFILES)
 
+copywriteheaders:
+	copywrite headers --plan
+
 # dev creates binaries for testing locally - these are put into ./bin and
 # $GOPATH
 dev:
@@ -60,4 +63,4 @@ vet:
 		exit 1; \
 	fi
 
-.PHONY: default bin cov format dev dist get-tools subnet test testrace tools vet
+.PHONY: default bin cov format dev dist get-tools subnet test testrace tools vet copywriteheaders

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright IBM Corp. 2013, 2025
+Copyright IBM Corp. 2013, 2026
 
 Mozilla Public License, version 2.0
 

--- a/client/const.go
+++ b/client/const.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package client

--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package client

--- a/cmd/serf/command/agent/agent.go
+++ b/cmd/serf/command/agent/agent.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/agent_test.go
+++ b/cmd/serf/command/agent/agent_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/command.go
+++ b/cmd/serf/command/agent/command.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/command_test.go
+++ b/cmd/serf/command/agent/command_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/config.go
+++ b/cmd/serf/command/agent/config.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/config_test.go
+++ b/cmd/serf/command/agent/config_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/event_handler.go
+++ b/cmd/serf/command/agent/event_handler.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/event_handler_mock.go
+++ b/cmd/serf/command/agent/event_handler_mock.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/event_handler_test.go
+++ b/cmd/serf/command/agent/event_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/flag_slice_value.go
+++ b/cmd/serf/command/agent/flag_slice_value.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/flag_slice_value_test.go
+++ b/cmd/serf/command/agent/flag_slice_value_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/gated_writer.go
+++ b/cmd/serf/command/agent/gated_writer.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/gated_writer_test.go
+++ b/cmd/serf/command/agent/gated_writer_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/invoke.go
+++ b/cmd/serf/command/agent/invoke.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/ipc.go
+++ b/cmd/serf/command/agent/ipc.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/ipc_event_stream.go
+++ b/cmd/serf/command/agent/ipc_event_stream.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/ipc_event_stream_test.go
+++ b/cmd/serf/command/agent/ipc_event_stream_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/ipc_log_stream.go
+++ b/cmd/serf/command/agent/ipc_log_stream.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/ipc_log_stream_test.go
+++ b/cmd/serf/command/agent/ipc_log_stream_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/ipc_query_response_stream.go
+++ b/cmd/serf/command/agent/ipc_query_response_stream.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/log_levels.go
+++ b/cmd/serf/command/agent/log_levels.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/log_writer.go
+++ b/cmd/serf/command/agent/log_writer.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/log_writer_test.go
+++ b/cmd/serf/command/agent/log_writer_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/mdns.go
+++ b/cmd/serf/command/agent/mdns.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/rpc_client_test.go
+++ b/cmd/serf/command/agent/rpc_client_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/syslog.go
+++ b/cmd/serf/command/agent/syslog.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/syslog_test.go
+++ b/cmd/serf/command/agent/syslog_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/util.go
+++ b/cmd/serf/command/agent/util.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/agent/util_test.go
+++ b/cmd/serf/command/agent/util_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package agent

--- a/cmd/serf/command/event.go
+++ b/cmd/serf/command/event.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/event_test.go
+++ b/cmd/serf/command/event_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/force_leave.go
+++ b/cmd/serf/command/force_leave.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/force_leave_test.go
+++ b/cmd/serf/command/force_leave_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/info.go
+++ b/cmd/serf/command/info.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/info_test.go
+++ b/cmd/serf/command/info_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/join.go
+++ b/cmd/serf/command/join.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/join_test.go
+++ b/cmd/serf/command/join_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/keygen.go
+++ b/cmd/serf/command/keygen.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/keygen_test.go
+++ b/cmd/serf/command/keygen_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/keys.go
+++ b/cmd/serf/command/keys.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/keys_test.go
+++ b/cmd/serf/command/keys_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/leave.go
+++ b/cmd/serf/command/leave.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/leave_test.go
+++ b/cmd/serf/command/leave_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/members.go
+++ b/cmd/serf/command/members.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/members_test.go
+++ b/cmd/serf/command/members_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/monitor.go
+++ b/cmd/serf/command/monitor.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/output.go
+++ b/cmd/serf/command/output.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/output_test.go
+++ b/cmd/serf/command/output_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/query.go
+++ b/cmd/serf/command/query.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/query_test.go
+++ b/cmd/serf/command/query_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/reachability.go
+++ b/cmd/serf/command/reachability.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/reachability_test.go
+++ b/cmd/serf/command/reachability_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/rpc.go
+++ b/cmd/serf/command/rpc.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/rtt.go
+++ b/cmd/serf/command/rtt.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/rtt_test.go
+++ b/cmd/serf/command/rtt_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/tags.go
+++ b/cmd/serf/command/tags.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/tags_test.go
+++ b/cmd/serf/command/tags_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/util_test.go
+++ b/cmd/serf/command/util_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/command/version.go
+++ b/cmd/serf/command/version.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/cmd/serf/commands.go
+++ b/cmd/serf/commands.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package main

--- a/cmd/serf/main.go
+++ b/cmd/serf/main.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package main

--- a/coordinate/client.go
+++ b/coordinate/client.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package coordinate

--- a/coordinate/client_test.go
+++ b/coordinate/client_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package coordinate

--- a/coordinate/config.go
+++ b/coordinate/config.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package coordinate

--- a/coordinate/coordinate.go
+++ b/coordinate/coordinate.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package coordinate

--- a/coordinate/coordinate_test.go
+++ b/coordinate/coordinate_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package coordinate

--- a/coordinate/performance_test.go
+++ b/coordinate/performance_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package coordinate

--- a/coordinate/phantom.go
+++ b/coordinate/phantom.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package coordinate

--- a/coordinate/util_test.go
+++ b/coordinate/util_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package coordinate

--- a/demo/web-load-balancer/setup_load_balancer.sh
+++ b/demo/web-load-balancer/setup_load_balancer.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright IBM Corp. 2013, 2025
+# Copyright IBM Corp. 2013, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 #

--- a/demo/web-load-balancer/setup_serf.sh
+++ b/demo/web-load-balancer/setup_serf.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright IBM Corp. 2013, 2025
+# Copyright IBM Corp. 2013, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 #

--- a/demo/web-load-balancer/setup_web_server.sh
+++ b/demo/web-load-balancer/setup_web_server.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright IBM Corp. 2013, 2025
+# Copyright IBM Corp. 2013, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 #

--- a/demo/web-load-balancer/user_data/dump_user_data.py
+++ b/demo/web-load-balancer/user_data/dump_user_data.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright IBM Corp. 2013, 2025
+# Copyright IBM Corp. 2013, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 import base64

--- a/demo/web-load-balancer/user_data/load_balancer_user_data.sh
+++ b/demo/web-load-balancer/user_data/load_balancer_user_data.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright IBM Corp. 2013, 2025
+# Copyright IBM Corp. 2013, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 NODE_SETUP_URL="https://raw.github.com/hashicorp/serf/master/demo/web-load-balancer/setup_load_balancer.sh"

--- a/demo/web-load-balancer/user_data/web_user_data.sh
+++ b/demo/web-load-balancer/user_data/web_user_data.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright IBM Corp. 2013, 2025
+# Copyright IBM Corp. 2013, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 NODE_SETUP_URL="https://raw.github.com/hashicorp/serf/master/demo/web-load-balancer/setup_web_server.sh"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright IBM Corp. 2013, 2025
+# Copyright IBM Corp. 2013, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 #

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright IBM Corp. 2013, 2025
+# Copyright IBM Corp. 2013, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 set -e

--- a/scripts/dist_build.sh
+++ b/scripts/dist_build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright IBM Corp. 2013, 2025
+# Copyright IBM Corp. 2013, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 set -e

--- a/scripts/serf-builder/Dockerfile
+++ b/scripts/serf-builder/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2013, 2025
+# Copyright IBM Corp. 2013, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 FROM docker.mirror.hashicorp.services/debian:stable

--- a/scripts/setup_test_subnet.sh
+++ b/scripts/setup_test_subnet.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright IBM Corp. 2013, 2025
+# Copyright IBM Corp. 2013, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 #

--- a/scripts/start_cluster.sh
+++ b/scripts/start_cluster.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright IBM Corp. 2013, 2025
+# Copyright IBM Corp. 2013, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 SERF="./bin/serf"

--- a/serf/broadcast.go
+++ b/serf/broadcast.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/broadcast_test.go
+++ b/serf/broadcast_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/coalesce.go
+++ b/serf/coalesce.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/coalesce_member.go
+++ b/serf/coalesce_member.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/coalesce_member_test.go
+++ b/serf/coalesce_member_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/coalesce_test.go
+++ b/serf/coalesce_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/coalesce_user.go
+++ b/serf/coalesce_user.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/coalesce_user_test.go
+++ b/serf/coalesce_user_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/config.go
+++ b/serf/config.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/config_test.go
+++ b/serf/config_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/conflict_delegate.go
+++ b/serf/conflict_delegate.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/delegate.go
+++ b/serf/delegate.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/delegate_test.go
+++ b/serf/delegate_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/event.go
+++ b/serf/event.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/event_delegate.go
+++ b/serf/event_delegate.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/event_test.go
+++ b/serf/event_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/internal/race/race_disabled.go
+++ b/serf/internal/race/race_disabled.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build !race

--- a/serf/internal/race/race_enabled.go
+++ b/serf/internal/race/race_enabled.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build race

--- a/serf/internal_query.go
+++ b/serf/internal_query.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/internal_query_test.go
+++ b/serf/internal_query_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/keymanager.go
+++ b/serf/keymanager.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/keymanager_test.go
+++ b/serf/keymanager_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/lamport.go
+++ b/serf/lamport.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/lamport_test.go
+++ b/serf/lamport_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/merge_delegate.go
+++ b/serf/merge_delegate.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/merge_delegate_test.go
+++ b/serf/merge_delegate_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/messages.go
+++ b/serf/messages.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/messages_test.go
+++ b/serf/messages_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/ping_delegate.go
+++ b/serf/ping_delegate.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/query.go
+++ b/serf/query.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/query_test.go
+++ b/serf/query_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/serf_internals_test.go
+++ b/serf/serf_internals_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/serf_test.go
+++ b/serf/serf_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/snapshot.go
+++ b/serf/snapshot.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/serf/snapshot_test.go
+++ b/serf/snapshot_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package serf

--- a/testutil/addr.go
+++ b/testutil/addr.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package testutil

--- a/testutil/retry/retry.go
+++ b/testutil/retry/retry.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 // Package retry provides support for repeating operations in tests.

--- a/testutil/retry/retry_test.go
+++ b/testutil/retry/retry_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package retry

--- a/testutil/testlog.go
+++ b/testutil/testlog.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package testutil

--- a/testutil/testutil_test.go
+++ b/testutil/testutil_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package testutil

--- a/testutil/yield.go
+++ b/testutil/yield.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package testutil

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package version


### PR DESCRIPTION
Update all the copyright headers. Add a `make copywriteheaders` to check headers in CI.

Fixes: https://github.com/hashicorp/serf/pull/806

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Description

<!-- Provide a summary of what the PR does and why it is being submitted. -->

## Related Issue

<!-- If this PR is linked to any issue, provide the issue number or description here. Any related JIRA tickets can also be added here. -->

## How Has This Been Tested?

<!-- Describe how the changes have been tested. Provide test instructions or details. -->
