### PR TITLE
agent: prevent segfault in integration tests

### DIFF
--- a/cmd/serf/command/agent/command.go
+++ b/cmd/serf/command/agent/command.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/cli"
-	"github.com/hashicorp/go-metrics/compat"
+	metrics "github.com/hashicorp/go-metrics/compat"
 	gsyslog "github.com/hashicorp/go-syslog"
 	"github.com/hashicorp/logutils"
 	"github.com/hashicorp/memberlist"
@@ -454,8 +454,9 @@ func (c *Command) startAgent(config *Config, agent *Agent,
 
 		// Get the bind interface if any
 		iface, _ := config.MDNSNetworkInterface()
-
-		c.logger.Printf("[INFO] agent: Starting mDNS listener on interface %s", iface.Name)
+		if iface != nil {
+			c.logger.Printf("[INFO] agent: Starting mDNS listener on interface %s", iface.Name)
+		}
 
 		_, err := NewAgentMDNS(agent, logOutput, config.ReplayOnJoin,
 			config.NodeName, config.Discover, iface, local.Addr, int(local.Port), config.MDNS)


### PR DESCRIPTION
In #733 we introduced the ability to specify the interface for mDNS, but this causes a segfault in some integration tests where the interface is unset. Only print the interface name if we have a valid value.

Ref: https://hashicorp.atlassian.net/browse/NMD-1559
Ref: https://github.com/hashicorp/serf/pull/733
Fixes: https://github.com/hashicorp/serf/issues/783


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->