### PR TITLE
build: fix invalid armon/go-metrics imports

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,6 +14,7 @@ GIT_COMMIT_FLAG = $(GO_MODULE)/version.GitCommit=$(GIT_COMMIT)$(GIT_DIRTY)
 GO_MODULE = github.com/hashicorp/serf
 GO_LDFLAGS = -X $(GIT_COMMIT_FLAG)
 GO_PKGS ?= $(shell go list ./...)
+GO_TAGS = "hashicorpmetrics"
 
 # ----------------------------------------------------------
 # build and package for distribution

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.25.0
 
 require (
 	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
-	github.com/armon/go-metrics v0.4.1
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/hashicorp/cli v1.1.7
 	github.com/hashicorp/go-metrics v0.6.0
@@ -20,6 +19,7 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
+	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/fatih/color v1.16.0 // indirect

--- a/serf/ping_delegate.go
+++ b/serf/ping_delegate.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"time"
 
-	"github.com/armon/go-metrics"
+	metrics "github.com/hashicorp/go-metrics/compat"
 	"github.com/hashicorp/go-msgpack/v2/codec"
 	"github.com/hashicorp/memberlist"
 	"github.com/hashicorp/serf/coordinate"

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -19,7 +19,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/armon/go-metrics"
+	metrics "github.com/hashicorp/go-metrics/compat"
 	"github.com/hashicorp/go-msgpack/v2/codec"
 	"github.com/hashicorp/memberlist"
 	"github.com/hashicorp/serf/coordinate"


### PR DESCRIPTION
During work to adopt new owners for this library, we accidentally introduced a armon/go-metrics import, which breaks downstream builds.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->