### PR TITLE
handle pruning asynchronously

### DIFF
--- a/serf/serf.go
+++ b/serf/serf.go
@@ -1189,20 +1189,37 @@ func (s *Serf) handleNodeLeaveIntent(leaveMsg *messageLeave) bool {
 }
 
 // handlePrune waits for nodes that are leaving and then forcibly
-// erases a member from the list of members
+// erases a member from the list of members. This function is called
+// while the caller holds memberLock, but spawns a goroutine to avoid
+// blocking while sleeping.
 func (s *Serf) handlePrune(member *memberState) {
-	if member.Status == StatusLeaving {
-		time.Sleep(s.config.BroadcastTimeout + s.config.LeavePropagateDelay)
-	}
+	memberName := member.Name
+	memberAddr := member.Addr
+	memberStatus := member.Status
 
-	s.logger.Printf("[INFO] serf: EventMemberReap (forced): %s %s", member.Name, member.Addr)
+	go func() {
+		if memberStatus == StatusLeaving {
+			time.Sleep(s.config.BroadcastTimeout + s.config.LeavePropagateDelay)
+		}
 
-	//If we are leaving or left we may be in that list of members
-	if member.Status == StatusLeaving || member.Status == StatusLeft {
-		s.leftMembers = removeOldMember(s.leftMembers, member.Name)
-	}
-	s.eraseNode(member)
+		s.logger.Printf("[INFO] serf: EventMemberReap (forced): %s %s", memberName, memberAddr)
 
+		// Acquire lock to safely modify member state
+		s.memberLock.Lock()
+		defer s.memberLock.Unlock()
+
+		// Verify the member still exists and should be erased
+		m, ok := s.members[memberName]
+		if !ok {
+			return
+		}
+
+		// If we are leaving or left we may be in that list of members
+		if m.Status == StatusLeaving || m.Status == StatusLeft {
+			s.leftMembers = removeOldMember(s.leftMembers, memberName)
+		}
+		s.eraseNode(m)
+	}()
 }
 
 // handleNodeJoinIntent is called when a node broadcasts a


### PR DESCRIPTION
If we get a message to leave with the prune flag set, the handler sleeps for the broadcast timeout + leave propogation delay before erasing the node, in order to give the message time to propogate. But we're holding the `memberLock` mutex while doing so, preventing the node from handling most other packets. Fire off a goroutine to handle the pruning.

Ref: https://hashicorp.atlassian.net/browse/NMD-1625
Ref: https://hashicorp.atlassian.net/browse/PSA-2905

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->