### PR TITLE
bounds-check message field payloads prior to indexing/slicing them

### DIFF
--- a/serf/internal_query.go
+++ b/serf/internal_query.go
@@ -238,8 +238,14 @@ func (s *serfQueries) handleInstallKey(q *Query) {
 	response := nodeKeyResponse{Result: false}
 	keyring := s.serf.config.MemberlistConfig.Keyring
 	req := keyRequest{}
+	var err error
 
-	err := decodeMessage(q.Payload[1:], &req)
+	if len(q.Payload) < 1 {
+		s.logger.Printf("[ERR] serf: Invalid key request payload")
+		goto SEND
+	}
+
+	err = decodeMessage(q.Payload[1:], &req)
 	if err != nil {
 		s.logger.Printf("[ERR] serf: Failed to decode key request: %v", err)
 		goto SEND
@@ -280,8 +286,14 @@ func (s *serfQueries) handleUseKey(q *Query) {
 	response := nodeKeyResponse{Result: false}
 	keyring := s.serf.config.MemberlistConfig.Keyring
 	req := keyRequest{}
+	var err error
 
-	err := decodeMessage(q.Payload[1:], &req)
+	if len(q.Payload) < 1 {
+		s.logger.Printf("[ERR] serf: Invalid key request payload")
+		goto SEND
+	}
+
+	err = decodeMessage(q.Payload[1:], &req)
 	if err != nil {
 		s.logger.Printf("[ERR] serf: Failed to decode key request: %v", err)
 		goto SEND
@@ -320,8 +332,14 @@ func (s *serfQueries) handleRemoveKey(q *Query) {
 	response := nodeKeyResponse{Result: false}
 	keyring := s.serf.config.MemberlistConfig.Keyring
 	req := keyRequest{}
+	var err error
 
-	err := decodeMessage(q.Payload[1:], &req)
+	if len(q.Payload) < 1 {
+		s.logger.Printf("[ERR] serf: Invalid key request payload")
+		goto SEND
+	}
+
+	err = decodeMessage(q.Payload[1:], &req)
 	if err != nil {
 		s.logger.Printf("[ERR] serf: Failed to decode key request: %v", err)
 		goto SEND

--- a/serf/query.go
+++ b/serf/query.go
@@ -215,6 +215,9 @@ type NodeResponse struct {
 // a set of filers.
 func (s *Serf) shouldProcessQuery(filters [][]byte) bool {
 	for _, filter := range filters {
+		if len(filter) == 0 {
+			return false
+		}
 		switch filterType(filter[0]) {
 		case filterNodeType:
 			// Decode the filter


### PR DESCRIPTION
The `messageQueryType` message has a `Filters` slice that can potentially be empty, and when we index into that empty slice we'll panic. Similarly, the handlers for the various keyring messages are missing bounds checks on the `Payload` fields, which results in a panic when the slice an empty slice.

Ref: https://hashicorp.atlassian.net/browse/PSA-2905
Ref: https://hashicorp.atlassian.net/browse/NMD-1625

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->