### PR TITLE
Fix concurrent SetTags race on config.Tags

### DIFF
--- a/serf/delegate.go
+++ b/serf/delegate.go
@@ -20,9 +20,10 @@ type delegate struct {
 var _ memberlist.Delegate = &delegate{}
 
 func (d *delegate) NodeMeta(limit int) []byte {
-	roleBytes := d.serf.encodeTags(d.serf.config.Tags)
+	tags := d.serf.getTags()
+	roleBytes := d.serf.encodeTags(tags)
 	if len(roleBytes) > limit {
-		panic(fmt.Errorf("Node tags '%v' exceeds length limit of %d bytes", d.serf.config.Tags, limit))
+		panic(fmt.Errorf("Node tags '%v' exceeds length limit of %d bytes", tags, limit))
 	}
 
 	return roleBytes

--- a/serf/query.go
+++ b/serf/query.go
@@ -242,8 +242,7 @@ func (s *Serf) shouldProcessQuery(filters [][]byte) bool {
 			}
 
 			// Check if we match this regex
-			tags := s.config.Tags
-			matched, err := regexp.MatchString(filt.Expr, tags[filt.Tag])
+			matched, err := regexp.MatchString(filt.Expr, s.getTags()[filt.Tag])
 			if err != nil {
 				s.logger.Printf("[WARN] serf: failed to compile filter regex (%s): %v", filt.Expr, err)
 				return false

--- a/serf/serf.go
+++ b/serf/serf.go
@@ -67,6 +67,8 @@ type Serf struct {
 
 	broadcasts    *memberlist.TransmitLimitedQueue
 	config        *Config
+	tagsLock      sync.RWMutex // protects config.Tags
+	setTagsLock   sync.Mutex   // serializes memberlist.UpdateNode from SetTags
 	failedMembers []*memberState
 	leftMembers   []*memberState
 	memberlist    *memberlist.Memberlist
@@ -621,11 +623,21 @@ func (s *Serf) SetTags(tags map[string]string) error {
 			memberlist.MetaMaxSize)
 	}
 
-	// Update the config
+	s.tagsLock.Lock()
 	s.config.Tags = tags
+	s.tagsLock.Unlock()
 
-	// Trigger a memberlist update
+	// Serialize UpdateNode; memberlist is not safe for concurrent calls.
+	s.setTagsLock.Lock()
+	defer s.setTagsLock.Unlock()
 	return s.memberlist.UpdateNode(s.config.BroadcastTimeout)
+}
+
+func (s *Serf) getTags() map[string]string {
+	s.tagsLock.RLock()
+	tags := s.config.Tags
+	s.tagsLock.RUnlock()
+	return tags
 }
 
 // Join joins an existing Serf cluster. Returns the number of nodes

--- a/serf/serf_test.go
+++ b/serf/serf_test.go
@@ -2005,6 +2005,41 @@ func TestSerf_SetTags(t *testing.T) {
 		[]EventType{EventMemberJoin, EventMemberUpdate})
 }
 
+func TestSerf_SetTags_Concurrent(t *testing.T) {
+	ip1, returnFn1 := testutil.TakeIP()
+	defer returnFn1()
+
+	s1Config := testConfig(t, ip1)
+	s1Config.BroadcastTimeout = time.Millisecond
+	s1, err := Create(s1Config)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer s1.Shutdown()
+
+	const goroutines = 16
+	const iterations = 32
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Go(func() {
+			<-start
+			for j := 0; j < iterations; j++ {
+				tags := map[string]string{
+					"id": strconv.Itoa(i),
+					"n":  strconv.Itoa(j),
+				}
+				if err := s1.SetTags(tags); err != nil {
+					t.Errorf("SetTags: %v", err)
+					return
+				}
+			}
+		})
+	}
+	close(start)
+	wg.Wait()
+}
+
 func TestSerf_Query(t *testing.T) {
 	ip1, returnFn1 := testutil.TakeIP()
 	defer returnFn1()


### PR DESCRIPTION
## Description

`Serf.SetTags` wrote `config.Tags` without synchronization even though the `Serf` godoc states that all methods are safe to call concurrently. Concurrent `SetTags` calls (and concurrent reads via `NodeMeta` / query tag filters) race on the tag map, and concurrent `memberlist.UpdateNode` calls can also race.

This change:

- Protects `config.Tags` with `tagsLock`
- Snapshots tags under the lock for `NodeMeta` and query tag filters
- Serializes `memberlist.UpdateNode` from `SetTags`

## Related Issue

Fixes #621

## How Has This Been Tested?

```bash
go test -race -count=1 -timeout 90s -run 'TestSerf_SetTags$|TestSerf_SetTags_Concurrent' ./serf
go test -race -count=1 -timeout 120s ./serf
```

Added `TestSerf_SetTags_Concurrent`, which failed under `-race` before the lock and passes after.

### Contributor Checklist
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read and followed the [AI usage guide](../CONTRIBUTING.md#ai-usage).